### PR TITLE
Add visibility and opacity bindings for VTK actors

### DIFF
--- a/PresentationTest/VtkMvvmTestWindow.xaml
+++ b/PresentationTest/VtkMvvmTestWindow.xaml
@@ -18,17 +18,35 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
+
+        <!-- Extra binding tests -->
         <Grid>
-            <StackPanel Orientation="Horizontal">
-                <TextBlock Text="Brush diameter" />
-                <Slider Value="{Binding BrushVm.Diameter}"
-                        Minimum="1"
-                        Maximum="5"
-                        Width="200" />
-                <TextBlock Text="{Binding BrushVm.Diameter, StringFormat={}{0:F2}}" />
-                <TextBlock Text=" mm" />
+            <StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0 4">
+                    <TextBlock Text="Brush diameter" />
+                    <Slider Value="{Binding BrushVm.Diameter}"
+                            Minimum="1"
+                            Maximum="5"
+                            Width="200" />
+                    <TextBlock Text="{Binding BrushVm.Diameter, StringFormat={}{0:F2}}" />
+                    <TextBlock Text=" mm" />
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal" Margin="0 4">
+                    <TextBlock Text="Actor opacity" />
+                    <Slider Value="{Binding AxialVms[1].Opacity}"
+                            Minimum="0"
+                            Maximum="1"
+                            Width="200" />
+                    <TextBlock Text="{Binding AxialVms[1].Opacity, StringFormat={}{0:F2}}" />
+
+                    <TextBlock Text="Visible?" Margin="4 0" />
+                    <CheckBox IsChecked="{Binding AxialVms[1].Visible}" />
+                </StackPanel>
             </StackPanel>
+
         </Grid>
+
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />

--- a/VtkMvvm/ViewModels/BrushViewModel.cs
+++ b/VtkMvvm/ViewModels/BrushViewModel.cs
@@ -59,6 +59,32 @@ public class BrushViewModel : VtkElementViewModel
     /// </summary>
     public vtkAlgorithmOutput GetBrushGeometryPort() => _orientFilter.GetOutputPort();
 
+
+    private void SetDiameter(double diameter)
+    {
+        _brushSource.SetRadius(diameter / 2.0);
+        _brushSource.Modified();
+    }
+
+    private void SetHeight(double value)
+    {
+        _brushSource.SetHeight(value);
+        _brushSource.Modified();
+    }
+
+    private void SetOrientation(SliceOrientation orientation)
+    {
+        _orient.Identity();
+        switch (orientation)
+        {
+            case SliceOrientation.Sagittal: _orient.RotateZ(-90); break; // align normal from y to x
+            case SliceOrientation.Coronal: /*nothing*/ break; // already y
+            case SliceOrientation.Axial: _orient.RotateX(90); break; // align normal from y to z
+        }
+
+        _orient.Modified();
+    }
+
     #region Binable properties
 
     private double _diameter = 2.0;
@@ -109,31 +135,6 @@ public class BrushViewModel : VtkElementViewModel
     public double CenterY => _center.Y;
     public double CenterZ => _center.Z;
 
-    private void SetDiameter(double diameter)
-    {
-        _brushSource.SetRadius(diameter / 2.0);
-        _brushSource.Modified();
-    }
-
-    private void SetHeight(double value)
-    {
-        _brushSource.SetHeight(value);
-        _brushSource.Modified();
-    }
-
-    private void SetOrientation(SliceOrientation orientation)
-    {
-        _orient.Identity();
-        switch (orientation)
-        {
-            case SliceOrientation.Sagittal: _orient.RotateZ(-90); break; // align normal from y to x
-            case SliceOrientation.Coronal: /*nothing*/ break; // already y
-            case SliceOrientation.Axial: _orient.RotateX(90); break; // align normal from y to z
-        }
-
-        _orient.Modified();
-    }
-
     /// <summary>
     ///     For center update, we expose method to update x, y, z concurrently
     /// </summary>
@@ -148,6 +149,21 @@ public class BrushViewModel : VtkElementViewModel
         OnPropertyChanged(nameof(CenterX));
         OnPropertyChanged(nameof(CenterY));
         OnPropertyChanged(nameof(CenterZ));
+    }
+
+    public bool Visible
+    {
+        get => Actor.GetVisibility() == 1;
+        set
+        {
+            bool current = Actor.GetVisibility() == 1;
+            if (current == value) return;
+            Actor.SetVisibility(value ? 1 : 0);
+            Actor.Modified();
+
+            OnPropertyChanged();
+            OnModified();
+        }
     }
 
     #endregion

--- a/VtkMvvm/ViewModels/ImageOrthogonalSliceViewModel.cs
+++ b/VtkMvvm/ViewModels/ImageOrthogonalSliceViewModel.cs
@@ -70,6 +70,35 @@ public class ImageOrthogonalSliceViewModel : VtkElementViewModel
         }
     }
 
+    public double Opacity
+    {
+        get => Actor.GetOpacity();
+        set
+        {
+            if (Math.Abs(Actor.GetOpacity() - value) < 1e-3) return;
+            Actor.SetOpacity(value);
+            Actor.Modified();
+
+            OnPropertyChanged();
+            OnModified();
+        }
+    }
+
+    public bool Visible
+    {
+        get => Actor.GetVisibility() == 1;
+        set
+        {
+            bool current = Actor.GetVisibility() == 1;
+            if (current == value) return;
+            Actor.SetVisibility(value ? 1 : 0);
+            Actor.Modified();
+
+            OnPropertyChanged();
+            OnModified();
+        }
+    }
+
     private void SetSliceIndex(int sliceIndex)
     {
         Debug.WriteLine($"{Orientation}-SliceIndex: {sliceIndex}");


### PR DESCRIPTION
### Description

- Introduced `Opacity` and `Visible` properties in `ImageOrthogonalSliceViewModel` to control the visibility and state of actors.
- Updated the test window to provide UI bindings for the introduced properties, enabling interaction via sliders and checkboxes.
