### PR TITLE
Refactor colormapping implementation and related pipeline logic

### DIFF
--- a/PresentationTest/ViewModels/VtkMvvmTestWindowViewModel.cs
+++ b/PresentationTest/ViewModels/VtkMvvmTestWindowViewModel.cs
@@ -99,7 +99,7 @@ public class VtkMvvmTestWindowViewModel : ReactiveObject
         _obliqueLabelVm = new ImageObliqueSliceViewModel(sliceOrientation, labelMapPipe);
 
         // Add brushes that render on top of the image
-        _brushVm.Diameter = 5.0;
+        _brushVm.Diameter = 8.0;
 
         // Instantiate voxel-brush and cached
         double[]? spacing = _labelMap.GetSpacing();

--- a/PresentationTest/ViewModels/VtkMvvmTestWindowViewModel.cs
+++ b/PresentationTest/ViewModels/VtkMvvmTestWindowViewModel.cs
@@ -75,14 +75,12 @@ public class VtkMvvmTestWindowViewModel : ReactiveObject
         // Build the shared background image pipeline
         var bgPipe = ColoredImagePipelineBuilder
             .WithSharedImage(_background)
-            .WithLinearInterpolation(true)
             .Build();
 
         // Build the shared labelmap image pipeline
         _labelMap = CreateLabelMap(_background);
         var labelMapPipe = ColoredImagePipelineBuilder
             .WithSharedImage(_labelMap)
-            .WithLinearInterpolation(false)
             .WithRgbaLookupTable(_labelMapLut)
             .Build();
 

--- a/PresentationTest/ViewModels/VtkMvvmTestWindowViewModel.cs
+++ b/PresentationTest/ViewModels/VtkMvvmTestWindowViewModel.cs
@@ -174,6 +174,7 @@ public class VtkMvvmTestWindowViewModel : ReactiveObject
             SagittalVms[0].ForceRender();
             CoronalVms[0].ForceRender();
             ObliqueVms[0].ForceRender();
+            this.RaisePropertyChanged();
         }
     }
 
@@ -186,6 +187,7 @@ public class VtkMvvmTestWindowViewModel : ReactiveObject
             SagittalVms[0].ForceRender();
             CoronalVms[0].ForceRender();
             ObliqueVms[0].ForceRender();
+            this.RaisePropertyChanged();
         }
     }
 

--- a/PresentationTest/ViewModels/VtkMvvmTestWindowViewModel.cs
+++ b/PresentationTest/ViewModels/VtkMvvmTestWindowViewModel.cs
@@ -37,10 +37,7 @@ public class VtkMvvmTestWindowViewModel : ReactiveObject
 
     // Painting labelmap
     private readonly vtkCellPicker _picker = new();
-    private int _axialSliceIndex;
-    private int _coronalSliceIndex;
-    private int _sagittalSliceIndex;
-    private int _obliqueSliceIndex;
+
 
     // Background ViewModels: Axial, Coronal, Sagittal slice view models
     public ImageOrthogonalSliceViewModel[] AxialVms => [_axialVm, _axialLabelVm];
@@ -119,7 +116,11 @@ public class VtkMvvmTestWindowViewModel : ReactiveObject
         SetLabelOneVisibilityCommand = new DelegateCommand<bool?>(SetLabelOneVisibility);
         SetSliceOrientationCommand = new DelegateCommand(SetSliceOrientation);
     }
-
+    
+    private int _axialSliceIndex;
+    private int _coronalSliceIndex;
+    private int _sagittalSliceIndex;
+    private int _obliqueSliceIndex;
 
     public int AxialSliceIndex
     {
@@ -162,6 +163,29 @@ public class VtkMvvmTestWindowViewModel : ReactiveObject
             value = Math.Clamp(value, _obliqueVm.MinSliceIndex, _obliqueVm.MaxSliceIndex);
             this.RaiseAndSetIfChanged(ref _obliqueSliceIndex, value);
             SetSliceIndex(ObliqueVms, value);
+        }
+    }
+    public double WindowLevel
+    {
+        get => AxialVms[0].WindowLevel;  // we use the shared lut. so modify one and tell others to render. 
+        set
+        {
+            AxialVms[0].WindowLevel = value;
+            SagittalVms[0].ForceRender();
+            CoronalVms[0].ForceRender();
+            ObliqueVms[0].ForceRender();
+        }
+    }
+
+    public double WindowWidth
+    {
+        get => AxialVms[0].WindowWidth;
+        set
+        {
+            AxialVms[0].WindowWidth = value;
+            SagittalVms[0].ForceRender();
+            CoronalVms[0].ForceRender();
+            ObliqueVms[0].ForceRender();
         }
     }
 

--- a/PresentationTest/Views/VtkMvvmTestWindow.xaml
+++ b/PresentationTest/Views/VtkMvvmTestWindow.xaml
@@ -72,8 +72,8 @@
                                 IsSnapToTickEnabled="True"
                                 Minimum="-500"
                                 Maximum="1000"
-                                Value="{Binding SagittalVms[0].WindowLevel, Mode=TwoWay}" />
-                        <TextBlock Margin="0,5,5,0" Text="{Binding SagittalVms[0].WindowLevel}" />
+                                Value="{Binding WindowLevel, Mode=TwoWay}" />
+                        <TextBlock Margin="0,5,5,0" Text="{Binding WindowLevel}" />
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal">
@@ -84,8 +84,8 @@
                                 IsSnapToTickEnabled="True"
                                 Minimum="200"
                                 Maximum="1000"
-                                Value="{Binding SagittalVms[0].WindowWidth, Mode=TwoWay}" />
-                        <TextBlock Margin="0,5,5,0" Text="{Binding SagittalVms[0].WindowWidth}" />
+                                Value="{Binding WindowWidth, Mode=TwoWay}" />
+                        <TextBlock Margin="0,5,5,0" Text="{Binding WindowWidth}" />
                     </StackPanel>
                 </StackPanel>
 

--- a/PresentationTest/Views/VtkMvvmTestWindow.xaml
+++ b/PresentationTest/Views/VtkMvvmTestWindow.xaml
@@ -42,8 +42,8 @@
                 <StackPanel Margin="0,4" Orientation="Horizontal">
                     <TextBlock Text="Brush diameter" />
                     <Slider Width="200"
-                            Minimum="1"
-                            Maximum="5"
+                            Minimum="2"
+                            Maximum="10"
                             Value="{Binding BrushVm.Diameter}" />
                     <TextBlock Text="{Binding BrushVm.Diameter, StringFormat={}{0:F2}}" />
                     <TextBlock Text=" mm" />
@@ -70,8 +70,8 @@
                                    Text="Level:" />
                         <Slider Width="200"
                                 IsSnapToTickEnabled="True"
-                                Minimum="{Binding SagittalVms[0].ImageModel.ScalarRange[0]}"
-                                Maximum="{Binding SagittalVms[0].ImageModel.ScalarRange[1]}"
+                                Minimum="-500"
+                                Maximum="1000"
                                 Value="{Binding SagittalVms[0].WindowLevel, Mode=TwoWay}" />
                         <TextBlock Margin="0,5,5,0" Text="{Binding SagittalVms[0].WindowLevel}" />
                     </StackPanel>
@@ -82,8 +82,8 @@
                                    Text="Width:" />
                         <Slider Width="200"
                                 IsSnapToTickEnabled="True"
-                                Minimum="100000"
-                                Maximum="500000"
+                                Minimum="200"
+                                Maximum="1000"
                                 Value="{Binding SagittalVms[0].WindowWidth, Mode=TwoWay}" />
                         <TextBlock Margin="0,5,5,0" Text="{Binding SagittalVms[0].WindowWidth}" />
                     </StackPanel>

--- a/PresentationTest/Views/VtkMvvmTestWindow.xaml
+++ b/PresentationTest/Views/VtkMvvmTestWindow.xaml
@@ -34,10 +34,15 @@
                 </Style>
             </Grid.Resources>
             <StackPanel>
-                <TextBlock Margin="0,16"
-                           Text="Binding tests"
-                           FontWeight="Bold"
-                           FontSize="32" />
+                <StackPanel Margin="0 8">
+                    <TextBlock Margin="0,4"
+                               Text="Mouse events: "
+                               FontWeight="Bold"
+                               FontSize="18" />
+                    <TextBlock Text="Left drag: draw on labelmap"/>
+                    <TextBlock Text="Left drag + Alt: display at this position"/>
+                </StackPanel>
+
 
                 <StackPanel Margin="0,4" Orientation="Horizontal">
                     <TextBlock Text="Brush diameter" />

--- a/PresentationTest/Views/VtkMvvmTestWindow.xaml.cs
+++ b/PresentationTest/Views/VtkMvvmTestWindow.xaml.cs
@@ -42,6 +42,8 @@ public partial class VtkMvvmTestWindow : Window
     {
         vtkInteractorStyleImage style = new(); // 被attach的event會直接覆蓋
         vtkRenderWindowInteractor iren = control.Interactor;
+        
+
 
         MouseInteractorBuilder.Create(iren, style)
             .LeftMove((x, y) => _vm.OnControlGetBrushPosition(control, x, y))
@@ -49,7 +51,7 @@ public partial class VtkMvvmTestWindow : Window
             .LeftDrag((x, y) => _vm.OnControlGetMousePaintPosition(control, x, y), keys: KeyMask.None)
             .LeftDragRx(obs => obs
                 .Sample(TimeSpan.FromMilliseconds(33))
-                .ObserveOn(RxApp.MainThreadScheduler) // necessary
+                .ObserveOn(RxApp.MainThreadScheduler /*always render on UI thread*/) 
                 .Subscribe(_ => RenderControls()))
             .Scroll(forward =>
             {
@@ -63,8 +65,8 @@ public partial class VtkMvvmTestWindow : Window
             .DisposeWith(_disposables);
     }
 
-
-    private void RenderControls()
+    
+    private void RenderControls()  
     {
         AxialControl.Render();
         CoronalControl.Render();

--- a/VtkMvvm/Features/Builder/ColoredImagePipeline.cs
+++ b/VtkMvvm/Features/Builder/ColoredImagePipeline.cs
@@ -47,7 +47,7 @@ internal static class ColoredImagePipelineExtensions
     }
 
     // ---- Helpers ------------------------------------
-    private static void ConfigureColorMap(this vtkImageMapToColors colorMap, ColoredImagePipeline pipe)
+    public static void ConfigureColorMap(this vtkImageMapToColors colorMap, ColoredImagePipeline pipe)
     {
         colorMap.SetLookupTable(pipe.LookupTable);
 

--- a/VtkMvvm/Features/Builder/ColoredImagePipeline.cs
+++ b/VtkMvvm/Features/Builder/ColoredImagePipeline.cs
@@ -44,17 +44,12 @@ public sealed record ColoredImagePipeline(
         else actor.InterpolateOff();
     }
 
+   
     private void ConfigureColormap(vtkImageMapToColors mapToColors)
     {
         mapToColors.SetLookupTable(LookupTable);
-
-        if (IsRgba)
-        {
-            mapToColors.SetOutputFormatToRGBA();
-        }
-        else
-        {
-            mapToColors.SetOutputFormatToLuminance();
-        }
+        
+        if (IsRgba) mapToColors.SetOutputFormatToRGBA();
+        else mapToColors.SetOutputFormatToLuminance();
     }
 }

--- a/VtkMvvm/Features/Builder/ColoredImagePipeline.cs
+++ b/VtkMvvm/Features/Builder/ColoredImagePipeline.cs
@@ -13,43 +13,45 @@ public sealed record ColoredImagePipeline(
     vtkLookupTable LookupTable,
     bool IsRgba,
     bool IsLinearInterpolationOn
-)
+);
+
+internal static class ColoredImagePipelineExtensions
 {
     /// <summary>
     ///     Connect pipeline: Image -> ColorMap -> Actor
     /// </summary>
-    internal void Connect(vtkImageMapToColors mapToColors, vtkImageActor actor)
+    public static void Connect(this ColoredImagePipeline pipe, vtkImageMapToColors colorMap, vtkImageActor actor)
     {
-        ConfigureColormap(mapToColors);
+        colorMap.ConfigureColorMap(pipe);
 
-        mapToColors.SetInput(Image);
-        actor.SetInput(mapToColors.GetOutput());
+        colorMap.SetInput(pipe.Image);
+        actor.SetInput(colorMap.GetOutput());
 
-        if (IsLinearInterpolationOn) actor.InterpolateOn();
+        if (pipe.IsLinearInterpolationOn) actor.InterpolateOn();
         else actor.InterpolateOff();
     }
-
+    
     /// <summary>
     /// Connect pipeline: Image -> Reslice Image → ColorMap → Actor
     /// </summary>
-    internal void ConnectWithReslice(vtkImageMapToColors mapToColors, vtkImageReslice reslice, vtkImageActor actor)
+    public static void ConnectWithReslice(this ColoredImagePipeline pipe, vtkImageMapToColors colorMap, vtkImageReslice reslice, vtkImageActor actor)
     {
-        ConfigureColormap(mapToColors);
+        colorMap.ConfigureColorMap(pipe);
 
-        reslice.SetInput(Image);
-        mapToColors.SetInputConnection(reslice.GetOutputPort());
-        actor.SetInput(mapToColors.GetOutput());
+        reslice.SetInput(pipe.Image);
+        colorMap.SetInputConnection(reslice.GetOutputPort());
+        actor.SetInput(colorMap.GetOutput());
 
-        if (IsLinearInterpolationOn) actor.InterpolateOn();
+        if (pipe.IsLinearInterpolationOn) actor.InterpolateOn();
         else actor.InterpolateOff();
     }
 
-   
-    private void ConfigureColormap(vtkImageMapToColors mapToColors)
+    // ---- Helpers ------------------------------------
+    private static void ConfigureColorMap(this vtkImageMapToColors colorMap, ColoredImagePipeline pipe)
     {
-        mapToColors.SetLookupTable(LookupTable);
-        
-        if (IsRgba) mapToColors.SetOutputFormatToRGBA();
-        else mapToColors.SetOutputFormatToLuminance();
+        colorMap.SetLookupTable(pipe.LookupTable);
+
+        if (pipe.IsRgba) colorMap.SetOutputFormatToRGBA();
+        else colorMap.SetOutputFormatToLuminance();
     }
 }

--- a/VtkMvvm/Features/Builder/ColoredImagePipeline.cs
+++ b/VtkMvvm/Features/Builder/ColoredImagePipeline.cs
@@ -3,17 +3,18 @@ using VtkMvvm.ViewModels.Base;
 
 namespace VtkMvvm.Features.Builder;
 
+
 /// <summary>
 /// DTO for the shared vtk image pipeline with color mapping.
 /// The image data may be shared across multiple <see cref="VtkElementViewModel"/>.
 /// So the ViewModel should not dispose them. 
 /// </summary>
-public sealed record ColoredImagePipeline(
-    vtkImageData Image,
-    vtkLookupTable LookupTable,
-    bool IsRgba,
-    bool IsLinearInterpolationOn
-);
+public sealed class ColoredImagePipeline
+{
+    public required vtkImageData Image { get; init; }
+    public required vtkLookupTable LookupTable { get; init; }
+    public required bool IsRgba { get; init; }
+}
 
 // internal static class ColoredImagePipelineExtensions
 // {

--- a/VtkMvvm/Features/Builder/ColoredImagePipeline.cs
+++ b/VtkMvvm/Features/Builder/ColoredImagePipeline.cs
@@ -15,43 +15,43 @@ public sealed record ColoredImagePipeline(
     bool IsLinearInterpolationOn
 );
 
-internal static class ColoredImagePipelineExtensions
-{
-    /// <summary>
-    ///     Connect pipeline: Image -> ColorMap -> Actor
-    /// </summary>
-    public static void Connect(this ColoredImagePipeline pipe, vtkImageMapToColors colorMap, vtkImageActor actor)
-    {
-        colorMap.ConfigureColorMap(pipe);
-
-        colorMap.SetInput(pipe.Image);
-        actor.SetInput(colorMap.GetOutput());
-
-        if (pipe.IsLinearInterpolationOn) actor.InterpolateOn();
-        else actor.InterpolateOff();
-    }
-    
-    /// <summary>
-    /// Connect pipeline: Image -> Reslice Image → ColorMap → Actor
-    /// </summary>
-    public static void ConnectWithReslice(this ColoredImagePipeline pipe, vtkImageMapToColors colorMap, vtkImageReslice reslice, vtkImageActor actor)
-    {
-        colorMap.ConfigureColorMap(pipe);
-
-        reslice.SetInput(pipe.Image);
-        colorMap.SetInputConnection(reslice.GetOutputPort());
-        actor.SetInput(colorMap.GetOutput());
-
-        if (pipe.IsLinearInterpolationOn) actor.InterpolateOn();
-        else actor.InterpolateOff();
-    }
-
-    // ---- Helpers ------------------------------------
-    public static void ConfigureColorMap(this vtkImageMapToColors colorMap, ColoredImagePipeline pipe)
-    {
-        colorMap.SetLookupTable(pipe.LookupTable);
-
-        if (pipe.IsRgba) colorMap.SetOutputFormatToRGBA();
-        else colorMap.SetOutputFormatToLuminance();
-    }
-}
+// internal static class ColoredImagePipelineExtensions
+// {
+//     /// <summary>
+//     ///     Connect pipeline: Image -> ColorMap -> Actor
+//     /// </summary>
+//     public static void Connect(this ColoredImagePipeline pipe, vtkImageMapToColors colorMap, vtkImageActor actor)
+//     {
+//         colorMap.ConfigureColorMap(pipe);
+//
+//         colorMap.SetInput(pipe.Image);
+//         actor.SetInput(colorMap.GetOutput());
+//
+//         if (pipe.IsLinearInterpolationOn) actor.InterpolateOn();
+//         else actor.InterpolateOff();
+//     }
+//     
+//     /// <summary>
+//     /// Connect pipeline: Image -> Reslice Image → ColorMap → Actor
+//     /// </summary>
+//     public static void ConnectWithReslice(this ColoredImagePipeline pipe, vtkImageMapToColors colorMap, vtkImageReslice reslice, vtkImageActor actor)
+//     {
+//         colorMap.ConfigureColorMap(pipe);
+//
+//         reslice.SetInput(pipe.Image);
+//         colorMap.SetInputConnection(reslice.GetOutputPort());
+//         actor.SetInput(colorMap.GetOutput());
+//
+//         if (pipe.IsLinearInterpolationOn) actor.InterpolateOn();
+//         else actor.InterpolateOff();
+//     }
+//
+//     // ---- Helpers ------------------------------------
+//     public static void ConfigureColorMap(this vtkImageMapToColors colorMap, ColoredImagePipeline pipe)
+//     {
+//         colorMap.SetLookupTable(pipe.LookupTable);
+//
+//         if (pipe.IsRgba) colorMap.SetOutputFormatToRGBA();
+//         else colorMap.SetOutputFormatToLuminance();
+//     }
+// }

--- a/VtkMvvm/Features/Builder/ColoredImagePipelineBuilder.cs
+++ b/VtkMvvm/Features/Builder/ColoredImagePipelineBuilder.cs
@@ -11,7 +11,6 @@ public class ColoredImagePipelineBuilder
     private readonly vtkImageData _image;
 
     // Configuration fields only:
-    private bool _linearInterpolation = true;
     private vtkLookupTable? _rgbaLookupTable; // null means Luminance
 
     private ColoredImagePipelineBuilder(vtkImageData image) => _image = image;
@@ -29,12 +28,6 @@ public class ColoredImagePipelineBuilder
         return grayLut;
     }
 
-    public ColoredImagePipelineBuilder WithLinearInterpolation(bool linear)
-    {
-        _linearInterpolation = linear;
-        return this;
-    }
-
     public ColoredImagePipelineBuilder WithRgbaLookupTable(vtkLookupTable lut)
     {
         _rgbaLookupTable = lut;
@@ -46,6 +39,11 @@ public class ColoredImagePipelineBuilder
         bool isRgba = _rgbaLookupTable != null;
         vtkLookupTable lut = _rgbaLookupTable ??= CreateDefaultGrayLut();
 
-        return new ColoredImagePipeline(_image, lut, isRgba, _linearInterpolation);
+        return new ColoredImagePipeline
+        {
+            Image = _image,
+            LookupTable = lut,
+            IsRgba = isRgba
+        };
     }
 }

--- a/VtkMvvm/Obsolete/OrientationCubeViewModel .cs
+++ b/VtkMvvm/Obsolete/OrientationCubeViewModel .cs
@@ -1,7 +1,7 @@
 ﻿using Kitware.VTK;
 using VtkMvvm.ViewModels.Base;
 
-namespace VtkMvvm.ViewModels;
+namespace VtkMvvm.Obsolete;
 
 /// <summary>
 /// A small “R L A P S I” orientation cube that can be dropped into an

--- a/VtkMvvm/Obsolete/OrientationLabelsViewModel.cs
+++ b/VtkMvvm/Obsolete/OrientationLabelsViewModel.cs
@@ -3,7 +3,7 @@ using Kitware.VTK;
 using VtkMvvm.Models;
 using VtkMvvm.ViewModels.Base;
 
-namespace VtkMvvm.ViewModels;
+namespace VtkMvvm.Obsolete;
 
 /// <summary>
 /// Flat “R / L / A / P / H/ F” text hints glued to the viewport edges.

--- a/VtkMvvm/ViewModels/Base/ImageSliceViewModel.cs
+++ b/VtkMvvm/ViewModels/Base/ImageSliceViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using Kitware.VTK;
 using VtkMvvm.Models;
 
 namespace VtkMvvm.ViewModels.Base;
@@ -9,6 +10,13 @@ namespace VtkMvvm.ViewModels.Base;
 /// </summary>
 public abstract class ImageSliceViewModel : VtkElementViewModel
 {
+    protected vtkImageMapToColors ColorMap { get; } = vtkImageMapToColors.New();
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing) ColorMap.Dispose();
+        base.Dispose(disposing);
+    } 
+    
     // ── slice orientation info ─────────────────────
     public Vector3 PlaneNormal { get; protected set; }
     public Vector3 PlaneAxisU { get; protected set; }

--- a/VtkMvvm/ViewModels/Base/ImageSliceViewModel.cs
+++ b/VtkMvvm/ViewModels/Base/ImageSliceViewModel.cs
@@ -51,8 +51,7 @@ public abstract class ImageSliceViewModel : VtkElementViewModel
             OnModified();
         }
     }
-
-
+    
     // ── slice orientation info ─────────────────────
     public Vector3 PlaneNormal { get; protected set; }
     public Vector3 PlaneAxisU { get; protected set; }
@@ -62,16 +61,16 @@ public abstract class ImageSliceViewModel : VtkElementViewModel
     // ── slice index (still abstract: each VM applies it differently)
     private int _sliceIndex = int.MinValue;
 
-    public int SliceIndex
+    public virtual int SliceIndex
     {
         get => _sliceIndex;
         set
         {
             if (!SetField(ref _sliceIndex, value)) return;
-            ApplySliceIndex(value); // concrete hook
+            OnSliceIndexChanged(value); // concrete hook
             OnModified();
         }
     }
 
-    protected abstract void ApplySliceIndex(int idx);
+    protected abstract void OnSliceIndexChanged(int idx);
 }

--- a/VtkMvvm/ViewModels/Base/ImageSliceViewModel.cs
+++ b/VtkMvvm/ViewModels/Base/ImageSliceViewModel.cs
@@ -12,19 +12,20 @@ namespace VtkMvvm.ViewModels.Base;
 /// </summary>
 public abstract class ImageSliceViewModel : VtkElementViewModel
 {
+    /// <summary>
+    /// Concrete actor override for displaying image slice in the scene
+    /// </summary>
+    public override vtkImageActor Actor { get; } = vtkImageActor.New();
+    
     // ── color map ─────────────────────
     private readonly IColorMappingStrategy _colorStrategy;
     
     /// <summary>
-    /// Maps sliced image to color and should be connected to the actor
+    /// Maps sliced image to the colors. Its output should be connected to the actor
     /// </summary>
     protected vtkImageMapToColors ColorMap { get; } = vtkImageMapToColors.New();
     
-    /// <summary>
-    /// Concrete actor for displaying image slice in the scene
-    /// </summary>
-    public override vtkImageActor Actor { get; } = vtkImageActor.New();
-
+    
     protected ImageSliceViewModel(ColoredImagePipeline pipe)
     {
         _colorStrategy = pipe.IsRgba ? new LabelMapColorMapping(pipe) : new WindowLevelColorMapping(pipe);
@@ -62,15 +63,33 @@ public abstract class ImageSliceViewModel : VtkElementViewModel
     }
     
     // ── slice orientation info ─────────────────────
+    
+    /// <summary>
+    /// Normal direction of the image slice
+    /// </summary>
     public Vector3 PlaneNormal { get; protected set; }
+    
+    /// <summary>
+    /// First axis direction of the image slice
+    /// </summary>
     public Vector3 PlaneAxisU { get; protected set; }
+    
+    /// <summary>
+    /// Second axis direction of the image slice
+    /// </summary>
     public Vector3 PlaneAxisV { get; protected set; }
+    
+    /// <summary>
+    /// World coordinate of the current image slice origin
+    /// </summary>
     public Double3 PlaneOrigin { get; protected set; }
 
-    // ── slice index (still abstract: each VM applies it differently)
+    // ── slice index (still abstract: each VM applies it differently) ─────────────────────
     private int _sliceIndex = int.MinValue;
 
-    /// <summary>Index of the slice to display. The setter raises OnSliceIndexChanged</summary>
+    /// <summary>
+    /// Index of the slice to display. The setter raises OnSliceIndexChanged
+    /// </summary>
     public int SliceIndex
     {
         get => _sliceIndex;

--- a/VtkMvvm/ViewModels/Base/ImageSliceViewModel.cs
+++ b/VtkMvvm/ViewModels/Base/ImageSliceViewModel.cs
@@ -10,13 +10,53 @@ namespace VtkMvvm.ViewModels.Base;
 /// </summary>
 public abstract class ImageSliceViewModel : VtkElementViewModel
 {
+    // color map ─────────────────────
     protected vtkImageMapToColors ColorMap { get; } = vtkImageMapToColors.New();
     protected override void Dispose(bool disposing)
     {
         if (disposing) ColorMap.Dispose();
         base.Dispose(disposing);
-    } 
+    }
     
+    private double _windowLevel;
+    private double _windowWidth;
+
+    public double WindowLevel
+    {
+        get => _windowLevel;
+        set
+        {
+            if (!SetField(ref _windowLevel, value)) return;
+            SetWindowBand(value, WindowWidth);
+            OnModified();
+        }
+    }
+
+    public double WindowWidth
+    {
+        get => _windowWidth;
+        set
+        {
+            if (!SetField(ref _windowWidth, value)) return;
+            SetWindowBand(WindowLevel, value);
+            OnModified();
+        }
+    }
+
+    private void SetWindowBand(double level, double width)
+    {
+        double low = level - width * 0.5;
+        double high = level + width * 0.5;
+
+        vtkScalarsToColors? lut = ColorMap.GetLookupTable();
+        lut.SetRange(low, high);
+        lut.Build();
+        ColorMap.SetLookupTable(lut);
+
+        ColorMap.Modified();
+        Actor.Modified();
+    }
+
     // ── slice orientation info ─────────────────────
     public Vector3 PlaneNormal { get; protected set; }
     public Vector3 PlaneAxisU { get; protected set; }

--- a/VtkMvvm/ViewModels/Base/ViewModelBase.cs
+++ b/VtkMvvm/ViewModels/Base/ViewModelBase.cs
@@ -1,0 +1,22 @@
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace VtkMvvm.ViewModels.Base;
+
+public abstract class ViewModelBase : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    protected bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return false;
+        field = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+}

--- a/VtkMvvm/ViewModels/Base/VtkElementViewModel.cs
+++ b/VtkMvvm/ViewModels/Base/VtkElementViewModel.cs
@@ -10,7 +10,7 @@ namespace VtkMvvm.ViewModels.Base;
 public abstract class VtkElementViewModel : INotifyPropertyChanged, IDisposable
 {
     public abstract vtkProp Actor { get; }
-    
+
     public bool Visible
     {
         get => Actor.GetVisibility() == 1;
@@ -25,13 +25,37 @@ public abstract class VtkElementViewModel : INotifyPropertyChanged, IDisposable
         }
     }
 
+    /// <summary>
+    ///     Force RenderWindow to render the scene. Generally used when the mutatable pipeline component has been modified
+    ///     externally.
+    /// </summary>
+    public void ForceRender() => OnModified();
+
+    public event EventHandler<EventArgs>? Modified;
+
+    /// <summary>
+    /// Notify RenderWindow to render the scene
+    /// </summary>
+    protected void OnModified()
+    {
+        Modified?.Invoke(this, EventArgs.Empty);
+    }
+
     public void Dispose()
     {
         Dispose(true);
         GC.SuppressFinalize(this);
     }
 
-
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Actor.Dispose();
+        }
+    }
+    
+    // ----------- implement INotifyPropertyChanged -------------------------------------
     public event PropertyChangedEventHandler? PropertyChanged;
 
     protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
@@ -46,30 +70,4 @@ public abstract class VtkElementViewModel : INotifyPropertyChanged, IDisposable
         OnPropertyChanged(propertyName);
         return true;
     }
-
-    protected virtual void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            Actor.Dispose();
-        }
-    }
-
-
-    #region Notify RenderWindow to render the scene
-
-    public event EventHandler<EventArgs>? Modified;
-
-    protected void OnModified()
-    {
-        Modified?.Invoke(this, EventArgs.Empty);
-    }
-
-    /// <summary>
-    ///     Force RenderWindow to render the scene. Generally used when the mutatable pipeline component has been modified
-    ///     externally.
-    /// </summary>
-    public void ForceRender() => OnModified();
-
-    #endregion
 }

--- a/VtkMvvm/ViewModels/Base/VtkElementViewModel.cs
+++ b/VtkMvvm/ViewModels/Base/VtkElementViewModel.cs
@@ -1,13 +1,11 @@
-﻿using System.ComponentModel;
-using System.Runtime.CompilerServices;
-using Kitware.VTK;
+﻿using Kitware.VTK;
 
 namespace VtkMvvm.ViewModels.Base;
 
 /// <summary>
 ///     Abstract base ViewModel that can be put into RenderWindow control
 /// </summary>
-public abstract class VtkElementViewModel : INotifyPropertyChanged, IDisposable
+public abstract class VtkElementViewModel : ViewModelBase, IDisposable
 {
     public abstract vtkProp Actor { get; }
 
@@ -53,21 +51,5 @@ public abstract class VtkElementViewModel : INotifyPropertyChanged, IDisposable
         {
             Actor.Dispose();
         }
-    }
-    
-    // ----------- implement INotifyPropertyChanged -------------------------------------
-    public event PropertyChangedEventHandler? PropertyChanged;
-
-    protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
-    {
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-    }
-
-    protected bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
-    {
-        if (EqualityComparer<T>.Default.Equals(field, value)) return false;
-        field = value;
-        OnPropertyChanged(propertyName);
-        return true;
     }
 }

--- a/VtkMvvm/ViewModels/BullseyeViewModel.cs
+++ b/VtkMvvm/ViewModels/BullseyeViewModel.cs
@@ -28,7 +28,7 @@ public sealed class BullseyeViewModel : VtkElementViewModel
     private (double R, double G, double B) _color = (1, 1, 0); // yellow
 
     // ── ctor/factory ────────────────────────────────────────────────
-    private BullseyeViewModel(Double3 centre,
+    public BullseyeViewModel(Double3 centre,
         Vector3 normal,
         int ringCount = 2,
         double ringSpacing = 2.0)

--- a/VtkMvvm/ViewModels/Components/IColorMappingStrategy.cs
+++ b/VtkMvvm/ViewModels/Components/IColorMappingStrategy.cs
@@ -5,7 +5,7 @@ namespace VtkMvvm.ViewModels.Components;
 /// <summary>
 /// Strategy pattern for mapping image data scalars to colors
 /// </summary>
-public interface IColorMappingStrategy : IDisposable
+internal interface IColorMappingStrategy : IDisposable
 {
     /// <summary>
     /// Apply this strategy. This is done by configuring <see cref="vtkImageMapToColors"/>

--- a/VtkMvvm/ViewModels/Components/IColorMappingStrategy.cs
+++ b/VtkMvvm/ViewModels/Components/IColorMappingStrategy.cs
@@ -1,0 +1,10 @@
+﻿using Kitware.VTK;
+
+namespace VtkMvvm.ViewModels.Components;
+
+public interface IColorMappingStrategy : IDisposable
+{
+    void Apply(vtkImageMapToColors cmap);
+
+    void Update();
+}

--- a/VtkMvvm/ViewModels/Components/IColorMappingStrategy.cs
+++ b/VtkMvvm/ViewModels/Components/IColorMappingStrategy.cs
@@ -2,9 +2,15 @@
 
 namespace VtkMvvm.ViewModels.Components;
 
+/// <summary>
+/// Strategy pattern for mapping image data scalars to colors
+/// </summary>
 public interface IColorMappingStrategy : IDisposable
 {
+    /// <summary>
+    /// Apply this strategy. This is done by configuring <see cref="vtkImageMapToColors"/>
+    /// </summary>
     void Apply(vtkImageMapToColors cmap);
-
+    
     void Update();
 }

--- a/VtkMvvm/ViewModels/Components/LabelMapMappingStrategy.cs
+++ b/VtkMvvm/ViewModels/Components/LabelMapMappingStrategy.cs
@@ -17,6 +17,7 @@ internal sealed class LabelMapColorMapping : IColorMappingStrategy
     {
         _cmap = cmap;
         _cmap.SetLookupTable(_lut);
+        _cmap.SetOutputFormatToRGBA();
         _cmap.PassAlphaToOutputOn();
         Update();
     }

--- a/VtkMvvm/ViewModels/Components/LabelMapMappingStrategy.cs
+++ b/VtkMvvm/ViewModels/Components/LabelMapMappingStrategy.cs
@@ -1,0 +1,27 @@
+﻿using Kitware.VTK;
+using VtkMvvm.Features.Builder;
+
+namespace VtkMvvm.ViewModels.Components;
+
+public sealed class LabelMapColorMapping : IColorMappingStrategy
+{
+    private readonly vtkLookupTable _lut;
+    private vtkImageMapToColors? _cmap;
+
+    public LabelMapColorMapping(ColoredImagePipeline pipe)
+    {
+        _lut = pipe.LookupTable;
+    }
+
+    public void Apply(vtkImageMapToColors cmap)
+    {
+        _cmap = cmap;
+        _cmap.SetLookupTable(_lut);
+        _cmap.PassAlphaToOutputOn();
+        Update();
+    }
+
+    public void Update() { /* nothing dynamic for now */ }
+
+    public void Dispose() => _lut.Dispose();
+}

--- a/VtkMvvm/ViewModels/Components/LabelMapMappingStrategy.cs
+++ b/VtkMvvm/ViewModels/Components/LabelMapMappingStrategy.cs
@@ -3,7 +3,7 @@ using VtkMvvm.Features.Builder;
 
 namespace VtkMvvm.ViewModels.Components;
 
-public sealed class LabelMapColorMapping : IColorMappingStrategy
+internal sealed class LabelMapColorMapping : IColorMappingStrategy
 {
     private readonly vtkLookupTable _lut;
     private vtkImageMapToColors? _cmap;

--- a/VtkMvvm/ViewModels/Components/WindowLevelMappingStrategy.cs
+++ b/VtkMvvm/ViewModels/Components/WindowLevelMappingStrategy.cs
@@ -1,0 +1,66 @@
+﻿using Kitware.VTK;
+using VtkMvvm.ViewModels.Base;
+
+namespace VtkMvvm.ViewModels.Components;
+
+public sealed class WindowLevelColorMapping : ViewModelBase, IColorMappingStrategy
+{
+    private readonly vtkLookupTable _lut = vtkLookupTable.New();
+    private vtkImageMapToColors? _cmap;
+
+    private double _window = 400;
+    private double _level = 40;
+
+    public double Window
+    {
+        get => _window;
+        set
+        {
+            if (_window != value)
+            {
+                _window = value;
+                Update();
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public double Level
+    {
+        get => _level;
+        set
+        {
+            if (_level != value)
+            {
+                _level = value;
+                Update();
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public void Apply(vtkImageMapToColors cmap)
+    {
+        _cmap = cmap;
+        _cmap.SetLookupTable(_lut);
+        _cmap.PassAlphaToOutputOn();
+        Update();
+    }
+
+    public void Update()
+    {
+        if (_cmap == null) return;
+
+        double low = Level - Window / 2.0;
+        double high = Level + Window / 2.0;
+
+        _lut.SetRange(low, high); // maps scalar → [0,1]
+        _lut.SetValueRange(0.0, 1.0); // brightness
+        _lut.SetSaturationRange(0.0, 0.0); // greyscale
+        _lut.Build();
+
+        _cmap.Modified();
+    }
+
+    public void Dispose() => _lut.Dispose();
+}

--- a/VtkMvvm/ViewModels/Components/WindowLevelMappingStrategy.cs
+++ b/VtkMvvm/ViewModels/Components/WindowLevelMappingStrategy.cs
@@ -1,12 +1,18 @@
 ﻿using Kitware.VTK;
+using VtkMvvm.Features.Builder;
 using VtkMvvm.ViewModels.Base;
 
 namespace VtkMvvm.ViewModels.Components;
 
 public sealed class WindowLevelColorMapping : ViewModelBase, IColorMappingStrategy
 {
-    private readonly vtkLookupTable _lut = vtkLookupTable.New();
+    private readonly vtkLookupTable _lut;
     private vtkImageMapToColors? _cmap;
+
+    public WindowLevelColorMapping(ColoredImagePipeline pipe)
+    {
+        _lut = pipe.LookupTable;
+    }
 
     private double _window = 400;
     private double _level = 40;
@@ -16,12 +22,10 @@ public sealed class WindowLevelColorMapping : ViewModelBase, IColorMappingStrate
         get => _window;
         set
         {
-            if (_window != value)
-            {
-                _window = value;
-                Update();
-                OnPropertyChanged();
-            }
+            if (Math.Abs(_window - value) < 1e-3) return;
+            _window = value;
+            Update();
+            OnPropertyChanged();
         }
     }
 
@@ -30,12 +34,10 @@ public sealed class WindowLevelColorMapping : ViewModelBase, IColorMappingStrate
         get => _level;
         set
         {
-            if (_level != value)
-            {
-                _level = value;
-                Update();
-                OnPropertyChanged();
-            }
+            if (Math.Abs(_level - value) < 1e-3) return;
+            _level = value;
+            Update();
+            OnPropertyChanged();
         }
     }
 
@@ -43,7 +45,7 @@ public sealed class WindowLevelColorMapping : ViewModelBase, IColorMappingStrate
     {
         _cmap = cmap;
         _cmap.SetLookupTable(_lut);
-        _cmap.PassAlphaToOutputOn();
+        _cmap.PassAlphaToOutputOff();
         Update();
     }
 
@@ -63,4 +65,5 @@ public sealed class WindowLevelColorMapping : ViewModelBase, IColorMappingStrate
     }
 
     public void Dispose() => _lut.Dispose();
+    
 }

--- a/VtkMvvm/ViewModels/Components/WindowLevelMappingStrategy.cs
+++ b/VtkMvvm/ViewModels/Components/WindowLevelMappingStrategy.cs
@@ -45,6 +45,7 @@ internal sealed class WindowLevelColorMapping : ViewModelBase, IColorMappingStra
     {
         _cmap = cmap;
         _cmap.SetLookupTable(_lut);
+        _cmap.SetOutputFormatToLuminance();
         _cmap.PassAlphaToOutputOff();
         Update();
     }

--- a/VtkMvvm/ViewModels/Components/WindowLevelMappingStrategy.cs
+++ b/VtkMvvm/ViewModels/Components/WindowLevelMappingStrategy.cs
@@ -4,7 +4,7 @@ using VtkMvvm.ViewModels.Base;
 
 namespace VtkMvvm.ViewModels.Components;
 
-public sealed class WindowLevelColorMapping : ViewModelBase, IColorMappingStrategy
+internal sealed class WindowLevelColorMapping : ViewModelBase, IColorMappingStrategy
 {
     private readonly vtkLookupTable _lut;
     private vtkImageMapToColors? _cmap;

--- a/VtkMvvm/ViewModels/CrosshairViewModel.cs
+++ b/VtkMvvm/ViewModels/CrosshairViewModel.cs
@@ -26,7 +26,7 @@ public sealed class CrosshairViewModel : VtkElementViewModel
     private Double3 _focalPoint;
     private float _lineWidth = 1.5F;
     
-    private CrosshairViewModel(
+    public CrosshairViewModel(
         Vector3 uDir,
         Vector3 vDir,
         Bounds lineBounds)

--- a/VtkMvvm/ViewModels/ImageObliqueSliceViewModel.cs
+++ b/VtkMvvm/ViewModels/ImageObliqueSliceViewModel.cs
@@ -29,9 +29,7 @@ public sealed class ImageObliqueSliceViewModel : ImageSliceViewModel
     private Quaternion _sliceOrientation = Quaternion.Identity;
 
 
-    public ImageObliqueSliceViewModel(
-        Quaternion orientation,
-        ColoredImagePipeline pipeline)
+    public ImageObliqueSliceViewModel(Quaternion orientation, ColoredImagePipeline pipeline) : base(pipeline)
     {
         vtkImageData volume = pipeline.Image;
         _imgCentre = volume.GetCenter();
@@ -41,7 +39,6 @@ public sealed class ImageObliqueSliceViewModel : ImageSliceViewModel
         // -------- connect full display pipeline ---------------------
         var slicePort = BuildObliqueSlice(volume);
         ColorMap.SetInputConnection(slicePort);
-        ColorMap.ConfigureColorMap(pipeline);
         _actor.SetInput(ColorMap.GetOutput());
         _actor.SetUserTransform(_xfm); // positions slice in 3-D
         Actor = _actor;

--- a/VtkMvvm/ViewModels/ImageObliqueSliceViewModel.cs
+++ b/VtkMvvm/ViewModels/ImageObliqueSliceViewModel.cs
@@ -15,7 +15,6 @@ public sealed class ImageObliqueSliceViewModel : ImageSliceViewModel
 {
     // ── VTK pipeline ────────────────────────────────────────────────
     private readonly vtkImageReslice _reslice = vtkImageReslice.New();
-    private readonly vtkImageMapToColors _cmap = vtkImageMapToColors.New();
     private readonly vtkTransform _xfm = vtkTransform.New();
     private readonly vtkMatrix4x4 _axes = vtkMatrix4x4.New(); // reslice axes
     private readonly vtkImageActor _actor = vtkImageActor.New();
@@ -51,7 +50,7 @@ public sealed class ImageObliqueSliceViewModel : ImageSliceViewModel
 
         // -------- connect full display pipeline ---------------------
         _actor.SetUserTransform(_xfm); // ***positions slice in 3-D***
-        pipeline.ConnectWithReslice(_cmap, _reslice, _actor);
+        pipeline.ConnectWithReslice(ColorMap, _reslice, _actor);
         Actor = _actor;
 
         // -------- initialise orientation & index --------------------
@@ -215,7 +214,6 @@ public sealed class ImageObliqueSliceViewModel : ImageSliceViewModel
         if (disposing)
         {
             _actor.Dispose();
-            _cmap.Dispose();
             _reslice.Dispose();
             _xfm.Dispose();
             _axes.Dispose();

--- a/VtkMvvm/ViewModels/ImageObliqueSliceViewModel.cs
+++ b/VtkMvvm/ViewModels/ImageObliqueSliceViewModel.cs
@@ -39,9 +39,8 @@ public sealed class ImageObliqueSliceViewModel : ImageSliceViewModel
         // -------- connect full display pipeline ---------------------
         var slicePort = BuildObliqueSlice(volume);
         ColorMap.SetInputConnection(slicePort);
-        _actor.SetInput(ColorMap.GetOutput());
-        _actor.SetUserTransform(_xfm); // positions slice in 3-D
-        Actor = _actor;
+        Actor.SetInput(ColorMap.GetOutput());
+        Actor.SetUserTransform(_xfm); // positions slice in 3-D
 
         // -------- initialise orientation & index --------------------
         SliceOrientation = orientation; // sets step & slider limits
@@ -62,7 +61,6 @@ public sealed class ImageObliqueSliceViewModel : ImageSliceViewModel
     }
 
     // ── public surface  ─────────────────────
-    public override vtkImageActor Actor { get; }
 
     /// <summary>
     /// Δ mm per slice index

--- a/VtkMvvm/ViewModels/ImageObliqueSliceViewModel.cs
+++ b/VtkMvvm/ViewModels/ImageObliqueSliceViewModel.cs
@@ -68,8 +68,7 @@ public sealed class ImageObliqueSliceViewModel : ImageSliceViewModel
     /// Δ mm per slice index
     /// </summary>
     public double StepMillimeter { get; private set; }
-
-
+    
     public Quaternion SliceOrientation
     {
         get => _sliceOrientation;
@@ -176,11 +175,11 @@ public sealed class ImageObliqueSliceViewModel : ImageSliceViewModel
 
         // ----- keep current index inside the new range --------------
         SliceIndex = Math.Clamp(SliceIndex, _minSliceIdx, _maxSliceIdx);
-        ApplySliceIndex(SliceIndex); // ★ always update slice idx to fit the current transform
+        OnSliceIndexChanged(SliceIndex); // ★ always update slice idx to fit the current transform
     }
 
     /// <summary>Move the slice plane along its normal by idx · Δ.</summary>
-    protected override void ApplySliceIndex(int idx)
+    protected override void OnSliceIndexChanged(int idx)
     {
         // current normal (3rd column)
         double nx = _axes.GetElement(0, 2);

--- a/VtkMvvm/ViewModels/ImageOrthogonalSliceViewModel.cs
+++ b/VtkMvvm/ViewModels/ImageOrthogonalSliceViewModel.cs
@@ -18,21 +18,23 @@ public sealed class ImageOrthogonalSliceViewModel : ImageSliceViewModel
     private double _windowLevel;
     private double _windowWidth;
 
-    public ImageOrthogonalSliceViewModel(SliceOrientation orientation, ColoredImagePipeline pipeline)
+    public ImageOrthogonalSliceViewModel(SliceOrientation orientation, ColoredImagePipeline pipe)
     {
         Orientation = orientation;
         (PlaneAxisU, PlaneAxisV) = GetPlaneAxes(orientation);
         PlaneNormal = Vector3.Normalize(Vector3.Cross(PlaneAxisU, PlaneAxisV));
 
-        vtkImageData image = pipeline.Image;
+        vtkImageData image = pipe.Image;
         _origin = image.GetOrigin();
         _spacing = image.GetSpacing();
 
         vtkImageActor actor = vtkImageActor.New();
         Actor = actor;
         ImageModel = ImageModel.Create(image);
-        pipeline.Connect(_cmap, actor);
-
+        
+        // VTK plumping
+        pipe.Connect(_cmap, actor);
+        
         // SetSliceIndex here is necessary.
         // This not only affects which slice it initially displayed, but also affects how the View recognizes the slicing orientation
         SliceIndex = 0;

--- a/VtkMvvm/ViewModels/ImageOrthogonalSliceViewModel.cs
+++ b/VtkMvvm/ViewModels/ImageOrthogonalSliceViewModel.cs
@@ -29,7 +29,9 @@ public sealed class ImageOrthogonalSliceViewModel : ImageSliceViewModel
         ImageModel = ImageModel.Create(image);
         
         // VTK plumping
-        pipe.Connect(ColorMap, actor);
+        ColorMap.ConfigureColorMap(pipe);
+        ColorMap.SetInput(pipe.Image);
+        actor.SetInput(ColorMap.GetOutput());
         
         // SetSliceIndex here is necessary.
         // This not only affects which slice it initially displayed, but also affects how the View recognizes the slicing orientation

--- a/VtkMvvm/ViewModels/ImageOrthogonalSliceViewModel.cs
+++ b/VtkMvvm/ViewModels/ImageOrthogonalSliceViewModel.cs
@@ -66,7 +66,7 @@ public sealed class ImageOrthogonalSliceViewModel : ImageSliceViewModel
     }
     
 
-    protected override void ApplySliceIndex(int idx)
+    protected override void OnSliceIndexChanged(int idx)
     {
         int[] dims = ImageModel.Dimensions;
 

--- a/VtkMvvm/ViewModels/ImageOrthogonalSliceViewModel.cs
+++ b/VtkMvvm/ViewModels/ImageOrthogonalSliceViewModel.cs
@@ -14,9 +14,6 @@ public sealed class ImageOrthogonalSliceViewModel : ImageSliceViewModel
     private readonly double[] _origin;
     private readonly double[] _spacing;
 
-    private double _windowLevel;
-    private double _windowWidth;
-
     public ImageOrthogonalSliceViewModel(SliceOrientation orientation, ColoredImagePipeline pipe)
     {
         Orientation = orientation;
@@ -52,27 +49,7 @@ public sealed class ImageOrthogonalSliceViewModel : ImageSliceViewModel
     public override vtkImageActor Actor { get; }
 
 
-    public double WindowLevel
-    {
-        get => _windowLevel;
-        set
-        {
-            if (!SetField(ref _windowLevel, value)) return;
-            SetWindowBand(value, WindowWidth);
-            OnModified();
-        }
-    }
-
-    public double WindowWidth
-    {
-        get => _windowWidth;
-        set
-        {
-            if (!SetField(ref _windowWidth, value)) return;
-            SetWindowBand(WindowLevel, value);
-            OnModified();
-        }
-    }
+    
 
     public double Opacity
     {
@@ -122,20 +99,6 @@ public sealed class ImageOrthogonalSliceViewModel : ImageSliceViewModel
         PlaneOrigin = new Double3(ox, oy, oz);
         OnPropertyChanged(nameof(PlaneOrigin));
 
-        Actor.Modified();
-    }
-
-    private void SetWindowBand(double level, double width)
-    {
-        double low = level - width * 0.5;
-        double high = level + width * 0.5;
-
-        vtkScalarsToColors? lut = ColorMap.GetLookupTable();
-        lut.SetRange(low, high);
-        lut.Build();
-        ColorMap.SetLookupTable(lut);
-
-        ColorMap.Modified();
         Actor.Modified();
     }
 }

--- a/VtkMvvm/ViewModels/ImageOrthogonalSliceViewModel.cs
+++ b/VtkMvvm/ViewModels/ImageOrthogonalSliceViewModel.cs
@@ -11,7 +11,6 @@ namespace VtkMvvm.ViewModels;
 /// </summary>
 public sealed class ImageOrthogonalSliceViewModel : ImageSliceViewModel
 {
-    private readonly vtkImageMapToColors _cmap = vtkImageMapToColors.New();
     private readonly double[] _origin;
     private readonly double[] _spacing;
 
@@ -33,7 +32,7 @@ public sealed class ImageOrthogonalSliceViewModel : ImageSliceViewModel
         ImageModel = ImageModel.Create(image);
         
         // VTK plumping
-        pipe.Connect(_cmap, actor);
+        pipe.Connect(ColorMap, actor);
         
         // SetSliceIndex here is necessary.
         // This not only affects which slice it initially displayed, but also affects how the View recognizes the slicing orientation
@@ -87,17 +86,7 @@ public sealed class ImageOrthogonalSliceViewModel : ImageSliceViewModel
             OnModified();
         }
     }
-
-
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            _cmap.Dispose();
-        }
-        base.Dispose(disposing);
-    }
-
+    
 
     protected override void ApplySliceIndex(int idx)
     {
@@ -141,12 +130,12 @@ public sealed class ImageOrthogonalSliceViewModel : ImageSliceViewModel
         double low = level - width * 0.5;
         double high = level + width * 0.5;
 
-        vtkScalarsToColors? lut = _cmap.GetLookupTable();
+        vtkScalarsToColors? lut = ColorMap.GetLookupTable();
         lut.SetRange(low, high);
         lut.Build();
-        _cmap.SetLookupTable(lut);
+        ColorMap.SetLookupTable(lut);
 
-        _cmap.Modified();
+        ColorMap.Modified();
         Actor.Modified();
     }
 }

--- a/VtkMvvm/ViewModels/ImageOrthogonalSliceViewModel.cs
+++ b/VtkMvvm/ViewModels/ImageOrthogonalSliceViewModel.cs
@@ -24,13 +24,11 @@ public sealed class ImageOrthogonalSliceViewModel : ImageSliceViewModel
         _origin = image.GetOrigin();
         _spacing = image.GetSpacing();
 
-        vtkImageActor actor = vtkImageActor.New();
-        Actor = actor;
         ImageModel = ImageModel.Create(image);
         
         // VTK plumping
         ColorMap.SetInput(pipe.Image);
-        actor.SetInput(ColorMap.GetOutput());
+        Actor.SetInput(ColorMap.GetOutput());
         
         // SetSliceIndex here is necessary.
         // This not only affects which slice it initially displayed, but also affects how the View recognizes the slicing orientation
@@ -47,10 +45,7 @@ public sealed class ImageOrthogonalSliceViewModel : ImageSliceViewModel
 
     public SliceOrientation Orientation { get; }
     public ImageModel ImageModel { get; }
-    public override vtkImageActor Actor { get; }
 
-
-    
 
     public double Opacity
     {

--- a/VtkMvvm/ViewModels/ImageOrthogonalSliceViewModel.cs
+++ b/VtkMvvm/ViewModels/ImageOrthogonalSliceViewModel.cs
@@ -14,7 +14,7 @@ public sealed class ImageOrthogonalSliceViewModel : ImageSliceViewModel
     private readonly double[] _origin;
     private readonly double[] _spacing;
 
-    public ImageOrthogonalSliceViewModel(SliceOrientation orientation, ColoredImagePipeline pipe)
+    public ImageOrthogonalSliceViewModel(SliceOrientation orientation, ColoredImagePipeline pipe) : base(pipe)
     {
         Orientation = orientation;
         (PlaneAxisU, PlaneAxisV) = GetPlaneAxes(orientation);
@@ -29,7 +29,6 @@ public sealed class ImageOrthogonalSliceViewModel : ImageSliceViewModel
         ImageModel = ImageModel.Create(image);
         
         // VTK plumping
-        ColorMap.ConfigureColorMap(pipe);
         ColorMap.SetInput(pipe.Image);
         actor.SetInput(ColorMap.GetOutput());
         


### PR DESCRIPTION
---

### Description

- The introduction of a colormapping strategy, enabling better separation of concerns between color mapping and geometrical slicing logic.

- Adjustments in how colormapping strategies and their related configurations are internally managed.
  - Set output format configurations for colormapping pipelines.
  - Removed linear interpolation configurations for color pipe builders.
  - Marked colormapping strategies as internal, managed exclusively via `ColorImagePipeline`.
- Enhanced class structure by overriding `vtkImageActor` in the base class and better aligning responsibilities amongst parent and child VMs.
- Renamed and reorganized methods for improved clarity (`ApplySliceIndex` renamed to `OnSliceIndexChanged`).
- General code organization improvements including inline comments, pipeline adjustments, and exposing constructors where appropriate for safe use.
