### PR TITLE
Refactor event handling with new BaseForwarder and VTK event types

### DIFF
--- a/PresentationTest/Views/DisposalTestWindow.xaml.cs
+++ b/PresentationTest/Views/DisposalTestWindow.xaml.cs
@@ -11,6 +11,7 @@ public partial class DisposalTestWindow : Window
 {
     private readonly CompositeDisposable _disposables = new();
     private DisposalTestWindowViewModel _vm;
+
     public DisposalTestWindow()
     {
         InitializeComponent();
@@ -25,12 +26,12 @@ public partial class DisposalTestWindow : Window
             _vm = vm;
         }
 
-        foreach (var control in new [] {AxialControl, CoronalControl})
+        foreach (var control in new[] { AxialControl, CoronalControl })
         {
             InitializeInteractorStyle(control);
         }
     }
-    
+
     /// <summary>
     /// Each controls has their own instance of freehand interactor
     /// </summary>
@@ -40,7 +41,7 @@ public partial class DisposalTestWindow : Window
         vtkRenderWindowInteractor iren = control.Interactor;
 
         MouseInteractorBuilder.Create(iren, style)
-            .LeftDrag((x, y) => _vm.OnControlGetMouseDisplayPosition(control, x, y), k: KeyMask.Alt)
+            .LeftDrag((x, y) => _vm.OnControlGetMouseDisplayPosition(control, x, y), KeyModifier.Alt)
             .Scroll(forward =>
             {
                 int increment = forward ? 1 : -1;

--- a/PresentationTest/Views/DisposalTestWindow.xaml.cs
+++ b/PresentationTest/Views/DisposalTestWindow.xaml.cs
@@ -40,7 +40,7 @@ public partial class DisposalTestWindow : Window
         vtkRenderWindowInteractor iren = control.Interactor;
 
         MouseInteractorBuilder.Create(iren, style)
-            .LeftDrag((x, y) => _vm.OnControlGetMouseDisplayPosition(control, x, y), keys: KeyMask.Alt)
+            .LeftDrag((x, y) => _vm.OnControlGetMouseDisplayPosition(control, x, y), k: KeyMask.Alt)
             .Scroll(forward =>
             {
                 int increment = forward ? 1 : -1;

--- a/PresentationTest/Views/VtkMvvmTestWindow.xaml.cs
+++ b/PresentationTest/Views/VtkMvvmTestWindow.xaml.cs
@@ -47,8 +47,8 @@ public partial class VtkMvvmTestWindow : Window, IDisposable
 
         MouseInteractorBuilder.Create(iren, style)
             .LeftMove((x, y) => _vm.OnControlGetBrushPosition(control, x, y))
-            .LeftDrag((x, y) => _vm.OnControlGetMouseDisplayPosition(control, x, y), k: KeyMask.Alt)
-            .LeftDrag((x, y) => _vm.OnControlGetMousePaintPosition(control, x, y), k: KeyMask.None)
+            .LeftDrag((x, y) => _vm.OnControlGetMouseDisplayPosition(control, x, y), KeyModifier.Alt)
+            .LeftDrag((x, y) => _vm.OnControlGetMousePaintPosition(control, x, y), KeyModifier.None)
             .LeftDragRx(obs => obs
                 .Sample(TimeSpan.FromMilliseconds(33))
                 .ObserveOn(RxApp.MainThreadScheduler /*always render on UI thread*/)

--- a/PresentationTest/Views/VtkMvvmTestWindow.xaml.cs
+++ b/PresentationTest/Views/VtkMvvmTestWindow.xaml.cs
@@ -47,8 +47,8 @@ public partial class VtkMvvmTestWindow : Window, IDisposable
 
         MouseInteractorBuilder.Create(iren, style)
             .LeftMove((x, y) => _vm.OnControlGetBrushPosition(control, x, y))
-            .LeftDrag((x, y) => _vm.OnControlGetMouseDisplayPosition(control, x, y), keys: KeyMask.Alt)
-            .LeftDrag((x, y) => _vm.OnControlGetMousePaintPosition(control, x, y), keys: KeyMask.None)
+            .LeftDrag((x, y) => _vm.OnControlGetMouseDisplayPosition(control, x, y), k: KeyMask.Alt)
+            .LeftDrag((x, y) => _vm.OnControlGetMousePaintPosition(control, x, y), k: KeyMask.None)
             .LeftDragRx(obs => obs
                 .Sample(TimeSpan.FromMilliseconds(33))
                 .ObserveOn(RxApp.MainThreadScheduler /*always render on UI thread*/)

--- a/VtkMvvm/Features/InteractorBehavior/BaseForwarder.cs
+++ b/VtkMvvm/Features/InteractorBehavior/BaseForwarder.cs
@@ -1,0 +1,51 @@
+﻿using System.Reactive.Subjects;
+using Kitware.VTK;
+
+namespace VtkMvvm.Features.InteractorBehavior;
+
+// ════════════════════════════════════════════════════════════════════════════════
+//  BaseForwarder — owns ALL native VTK hooks; publishes a "bus" of VtkEvent
+// ════════════════════════════════════════════════════════════════════════════════
+
+/// <summary>
+///  Make a single “event bus” (BaseForwarder) that owns the VTK hooks.
+///  Let <see cref="IInteractorBehavior"/> subscribe to the bus instead of VTK directly
+/// </summary>
+internal sealed class BaseForwarder : IObservable<VtkEvent>, IDisposable
+{
+    private readonly vtkInteractorStyle _style;
+    private readonly Subject<VtkEvent> _bus = new();
+    private readonly HashSet<VtkEventId> _swallow = new();
+
+    public BaseForwarder(vtkInteractorStyle style)
+    {
+        _style = style ?? throw new ArgumentNullException(nameof(style));
+
+        style.MouseMoveEvt += (_, _) => Publish(VtkEventId.MouseMove, () => style.OnMouseMove());
+        style.LeftButtonPressEvt += (_, _) => Publish(VtkEventId.LeftDown, () => style.OnLeftButtonDown());
+        style.LeftButtonReleaseEvt += (_, _) => Publish(VtkEventId.LeftUp, () => style.OnLeftButtonUp());
+        style.RightButtonPressEvt += (_, _) => Publish(VtkEventId.RightDown, () => style.OnRightButtonDown());
+        style.RightButtonReleaseEvt += (_, _) => Publish(VtkEventId.RightUp, () => style.OnRightButtonUp());
+        style.MiddleButtonPressEvt += (_, _) => Publish(VtkEventId.MiddleDown, () => style.OnMiddleButtonDown());
+        style.MiddleButtonReleaseEvt += (_, _) => Publish(VtkEventId.MiddleUp, () => style.OnMiddleButtonUp());
+        style.MouseWheelForwardEvt += (_, _) => Publish(VtkEventId.WheelForward, () => style.OnMouseWheelForward());
+        style.MouseWheelBackwardEvt += (_, _) => Publish(VtkEventId.WheelBackward, () => style.OnMouseWheelBackward());
+    }
+
+    public IDisposable Subscribe(IObserver<VtkEvent> observer) => _bus.Subscribe(observer);
+
+    /// <summary>Prevent a particular event from being forwarded to the native base style.</summary>
+    public void AddSwallow(VtkEventId evt) => _swallow.Add(evt);
+
+    private void Publish(VtkEventId id, Action forwardOnce)
+    {
+        // Push through the bus first (behaviours will listen).
+        var iren = _style.GetInteractor();
+        _bus.OnNext(new VtkEvent(id, iren));
+
+        if (!_swallow.Contains(id))
+            forwardOnce(); // exactly once per physical VTK event
+    }
+
+    public void Dispose() => _bus.Dispose();
+}

--- a/VtkMvvm/Features/InteractorBehavior/IInteractorBehavior.cs
+++ b/VtkMvvm/Features/InteractorBehavior/IInteractorBehavior.cs
@@ -12,9 +12,3 @@ public interface IInteractorBehavior
     void Detach();
 }
 
-public enum TriggerMouseButton
-{
-    Left,
-    Right,
-    Middle
-}

--- a/VtkMvvm/Features/InteractorBehavior/KeyModifier.cs
+++ b/VtkMvvm/Features/InteractorBehavior/KeyModifier.cs
@@ -4,10 +4,10 @@ namespace VtkMvvm.Features.InteractorBehavior;
 
 /// <summary>
 /// Combination of keyboard keys that must be held down for the callback to fire.
-/// The "None" requires strickly NO key is pressing.
+/// The "None" requires strictly NO key is pressing.
 /// </summary>
 [Flags]
-public enum KeyMask
+public enum KeyModifier
 {
     None = 0,
     Alt = 1,
@@ -17,18 +17,18 @@ public enum KeyMask
 
 internal static class KeyMaskExtensions
 {
-    public static bool IsSatisfied(this KeyMask mask, vtkRenderWindowInteractor iren)
+    public static bool IsSatisfied(this KeyModifier key, vtkRenderWindowInteractor iren)
     {
         bool alt = iren.GetAltKey() != 0;
         bool ctrl = iren.GetControlKey() != 0;
         bool shift = iren.GetShiftKey() != 0;
         
-        if (mask == KeyMask.None)
+        if (key == KeyModifier.None)
             return !alt && !ctrl && !shift; // ← strict zero
 
-        if (mask.HasFlag(KeyMask.Alt) && !alt) return false;
-        if (mask.HasFlag(KeyMask.Ctrl) && !ctrl) return false;
-        if (mask.HasFlag(KeyMask.Shift) && !shift) return false;
+        if (key.HasFlag(KeyModifier.Alt) && !alt) return false;
+        if (key.HasFlag(KeyModifier.Ctrl) && !ctrl) return false;
+        if (key.HasFlag(KeyModifier.Shift) && !shift) return false;
         return true;
     }
 }

--- a/VtkMvvm/Features/InteractorBehavior/KeyModifier.cs
+++ b/VtkMvvm/Features/InteractorBehavior/KeyModifier.cs
@@ -15,7 +15,7 @@ public enum KeyModifier
     Shift = 4,
 }
 
-internal static class KeyMaskExtensions
+internal static class KeyModifierExtensions
 {
     public static bool IsSatisfied(this KeyModifier key, vtkRenderWindowInteractor iren)
     {

--- a/VtkMvvm/Features/InteractorBehavior/MouseInteractorBehavior.cs
+++ b/VtkMvvm/Features/InteractorBehavior/MouseInteractorBehavior.cs
@@ -1,149 +1,59 @@
-﻿using System.Reactive.Linq;
+﻿// ════════════════════════════════════════════════════════════════════════════════
+//  Behaviour: mouse move / drag
+// ════════════════════════════════════════════════════════════════════════════════
+
+
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using Kitware.VTK;
 
 namespace VtkMvvm.Features.InteractorBehavior;
 
+
 /// <summary>
 ///     Represents a behavior that allows interaction with a visual area in response to mouse clicks and movements.
 /// </summary>
-public sealed class MouseInteractorBehavior
-    : IInteractorBehavior, IDisposable
+public sealed class MouseInteractorBehavior : IDisposable
 {
-    private readonly TriggerMouseButton _triggerButton;
-    private readonly Subject<(int x, int y)> _moveSubject = new();
+    private readonly Subject<(int x,int y)> _moves = new();
+    private readonly CompositeDisposable _d = new();
 
-    private vtkInteractorStyle? _style;
-
-    public MouseInteractorBehavior(TriggerMouseButton triggerButton) 
-    {
-        _triggerButton = triggerButton;
-    }
-
-    /// <summary>
-    ///     Exposes the click‐position stream as an IObservable.
-    ///     Subscribers will see (x,y) whenever the chosen button is moving.
-    /// </summary>
-    public IObservable<(int x, int y)> Moves => _moveSubject.AsObservable();
-
-    /// <summary>
-    ///     Exposed bool for filtering Moves observable.
-    /// </summary>
+    /// <summary>true while the trigger button is pressed.</summary>
     public bool IsPressing { get; private set; }
 
-    /// <summary>
-    /// If not override, will forward the base event handler
-    /// </summary>
-    public bool OverrideBaseStyle { get; set; } = false;
-    
+    public IObservable<(int x,int y)> Moves => _moves.AsObservable();
 
-    public void Dispose()
+    public MouseInteractorBehavior(IObservable<VtkEvent> bus, TriggerMouseButton trigger)
     {
-        Detach();
-        _moveSubject.Dispose();
-    }
-
-    public void AttachTo(vtkInteractorStyle style)
-    {
-        ArgumentNullException.ThrowIfNull(style);
-        _style = style;
-
-        _style.MouseMoveEvt += OnMouseMove;
-        switch (_triggerButton)
+        // Update IsPressing based on down/up events
+        _d.Add(bus.Subscribe(e =>
         {
-            case TriggerMouseButton.Left:
-                _style.LeftButtonPressEvt += OnButtonDown;
-                _style.LeftButtonReleaseEvt += OnButtonRelease;
-                break;
-            case TriggerMouseButton.Right:
-                _style.RightButtonPressEvt += OnButtonDown;
-                _style.RightButtonReleaseEvt += OnButtonRelease;
-                break;
-            case TriggerMouseButton.Middle:
-                _style.MiddleButtonPressEvt += OnButtonDown;
-                _style.MiddleButtonReleaseEvt += OnButtonRelease;
-                break;
-        }
+            IsPressing = e.Id switch
+            {
+                VtkEventId.LeftDown   when trigger == TriggerMouseButton.Left   => true,
+                VtkEventId.LeftUp     when trigger == TriggerMouseButton.Left   => false,
+                VtkEventId.RightDown  when trigger == TriggerMouseButton.Right  => true,
+                VtkEventId.RightUp    when trigger == TriggerMouseButton.Right  => false,
+                VtkEventId.MiddleDown when trigger == TriggerMouseButton.Middle => true,
+                VtkEventId.MiddleUp   when trigger == TriggerMouseButton.Middle => false,
+                _ => IsPressing
+            };
+        }));
+
+        // Emit (x,y) for every MouseMove event
+        _d.Add(bus
+            .Where(e => e.Id == VtkEventId.MouseMove)
+            .Select(e => GetMousePos(e.Iren))
+            .Subscribe(_moves));
     }
 
-    public void Detach()
+    private static (int x,int y) GetMousePos(vtkRenderWindowInteractor iren)
     {
-        if (_style is null) return;
-
-        _style.MouseMoveEvt -= OnMouseMove;
-        switch (_triggerButton)
-        {
-            case TriggerMouseButton.Left:
-                _style.LeftButtonPressEvt -= OnButtonDown;
-                _style.LeftButtonReleaseEvt -= OnButtonRelease;
-                break;
-            case TriggerMouseButton.Right:
-                _style.RightButtonPressEvt -= OnButtonDown;
-                _style.RightButtonReleaseEvt -= OnButtonRelease;
-                break;
-            case TriggerMouseButton.Middle:
-                _style.MiddleButtonPressEvt -= OnButtonDown;
-                _style.MiddleButtonReleaseEvt -= OnButtonRelease;
-                break;
-        }
-
-        _style = null;
+        Span<int> xy = stackalloc int[2];
+        unsafe { fixed(int* p = xy) iren.GetEventPosition((IntPtr)p); }
+        return (xy[0], xy[1]);
     }
 
-    private void OnButtonDown(vtkObject sender, vtkObjectEventArgs e)
-    {
-        IsPressing = true;
-        PushEventPosition();
-        if (OverrideBaseStyle) return;  // not forward base style handler
-        
-        switch (_triggerButton)
-        {
-            case TriggerMouseButton.Left:
-                _style!.OnLeftButtonDown();
-                break;
-            case TriggerMouseButton.Right:
-                _style!.OnRightButtonDown();
-                break;
-            case TriggerMouseButton.Middle:
-                _style!.OnMiddleButtonDown();
-                break;
-        }
-    }
-
-    private void OnMouseMove(vtkObject sender, vtkObjectEventArgs e)
-    {
-        PushEventPosition();
-        if (OverrideBaseStyle) return;   // not forward base style handler
-        
-        _style!.OnMouseMove();
-    }
-
-    private void OnButtonRelease(vtkObject sender, vtkObjectEventArgs e)
-    {
-        IsPressing = false;
-        if (OverrideBaseStyle) return;
-        
-        switch (_triggerButton)
-        {
-            case TriggerMouseButton.Left:
-                _style!.OnLeftButtonUp();
-                break;
-            case TriggerMouseButton.Right:
-                _style!.OnRightButtonUp();
-                break;
-            case TriggerMouseButton.Middle:
-                _style!.OnMiddleButtonUp();
-                break;
-        }
-    }
-
-    private unsafe void PushEventPosition()
-    {
-        Span<int> pos = stackalloc int[2];
-        fixed (int* p = pos)
-        {
-            _style!.GetInteractor().GetEventPosition((IntPtr)p);
-        }
-        _moveSubject.OnNext((pos[0], pos[1]));
-    }
+    public void Dispose() => _d.Dispose();
 }

--- a/VtkMvvm/Features/InteractorBehavior/MouseInteractorBehavior.cs
+++ b/VtkMvvm/Features/InteractorBehavior/MouseInteractorBehavior.cs
@@ -6,23 +6,23 @@
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using System.Runtime.CompilerServices;
 using Kitware.VTK;
 
 namespace VtkMvvm.Features.InteractorBehavior;
-
 
 /// <summary>
 ///     Represents a behavior that allows interaction with a visual area in response to mouse clicks and movements.
 /// </summary>
 public sealed class MouseInteractorBehavior : IDisposable
 {
-    private readonly Subject<(int x,int y)> _moves = new();
+    private readonly Subject<(int x, int y)> _moves = new();
     private readonly CompositeDisposable _d = new();
 
     /// <summary>true while the trigger button is pressed.</summary>
     public bool IsPressing { get; private set; }
 
-    public IObservable<(int x,int y)> Moves => _moves.AsObservable();
+    public IObservable<(int x, int y)> Moves => _moves.AsObservable();
 
     public MouseInteractorBehavior(IObservable<VtkEvent> bus, TriggerMouseButton trigger)
     {
@@ -31,12 +31,12 @@ public sealed class MouseInteractorBehavior : IDisposable
         {
             IsPressing = e.Id switch
             {
-                VtkEventId.LeftDown   when trigger == TriggerMouseButton.Left   => true,
-                VtkEventId.LeftUp     when trigger == TriggerMouseButton.Left   => false,
-                VtkEventId.RightDown  when trigger == TriggerMouseButton.Right  => true,
-                VtkEventId.RightUp    when trigger == TriggerMouseButton.Right  => false,
+                VtkEventId.LeftDown when trigger == TriggerMouseButton.Left => true,
+                VtkEventId.LeftUp when trigger == TriggerMouseButton.Left => false,
+                VtkEventId.RightDown when trigger == TriggerMouseButton.Right => true,
+                VtkEventId.RightUp when trigger == TriggerMouseButton.Right => false,
                 VtkEventId.MiddleDown when trigger == TriggerMouseButton.Middle => true,
-                VtkEventId.MiddleUp   when trigger == TriggerMouseButton.Middle => false,
+                VtkEventId.MiddleUp when trigger == TriggerMouseButton.Middle => false,
                 _ => IsPressing
             };
         }));
@@ -44,16 +44,24 @@ public sealed class MouseInteractorBehavior : IDisposable
         // Emit (x,y) for every MouseMove event
         _d.Add(bus
             .Where(e => e.Id == VtkEventId.MouseMove)
-            .Select(e => GetMousePos(e.Iren))
+            .Select(e => GetMousePosition(e.Iren))
             .Subscribe(_moves));
     }
 
-    private static (int x,int y) GetMousePos(vtkRenderWindowInteractor iren)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static (int x, int y) GetMousePosition(vtkRenderWindowInteractor iren)
     {
         Span<int> xy = stackalloc int[2];
-        unsafe { fixed(int* p = xy) iren.GetEventPosition((IntPtr)p); }
+        unsafe
+        {
+            fixed (int* p = xy) iren.GetEventPosition((IntPtr)p);
+        }
         return (xy[0], xy[1]);
     }
 
-    public void Dispose() => _d.Dispose();
+    public void Dispose()
+    {
+        _d.Dispose();
+        _moves.Dispose();
+    }
 }

--- a/VtkMvvm/Features/InteractorBehavior/MouseInteractorBuilder.cs
+++ b/VtkMvvm/Features/InteractorBehavior/MouseInteractorBuilder.cs
@@ -159,7 +159,7 @@ public sealed class MouseInteractorBuilder
         var beh = new MouseInteractorBehavior(_bus, mouseButton);
         _disposables.Add(beh);
         
-        // Filter the stream by pressing checks and keymask
+        // Filter the stream by checking whether the mouse button is pressing and keymask
         IObservable<(int x, int y)> stream = beh.Moves.Where(_ => key.IsSatisfied(_iren));
         if (isDrag) stream = stream.Where(_ => beh.IsPressing);
         

--- a/VtkMvvm/Features/InteractorBehavior/MouseInteractorBuilder.cs
+++ b/VtkMvvm/Features/InteractorBehavior/MouseInteractorBuilder.cs
@@ -33,134 +33,137 @@ public sealed class MouseInteractorBuilder
 {
     private readonly vtkRenderWindowInteractor _iren;
     private readonly BaseForwarder _bus;
-    private readonly CompositeDisposable _d = new();
+    private readonly CompositeDisposable _disposables = new();
 
-    private MouseInteractorBuilder(vtkRenderWindowInteractor iren, vtkInteractorStyle baseStyle)
+    private MouseInteractorBuilder(vtkRenderWindowInteractor interactor, vtkInteractorStyle baseInteractorStyle)
     {
-        _iren = iren;
-        _bus = new BaseForwarder(baseStyle);
-        _d.Add(_bus);
+        _iren = interactor;
+        _bus = new BaseForwarder(baseInteractorStyle);
+        _disposables.Add(_bus);
 
-        iren.SetInteractorStyle(baseStyle);
-        iren.Initialize();
+        interactor.SetInteractorStyle(baseInteractorStyle);
+        interactor.Initialize();
     }
 
-    public static MouseInteractorBuilder Create(vtkRenderWindowInteractor iren, vtkInteractorStyle baseStyle)
-        => new(iren, baseStyle);
+    public static MouseInteractorBuilder Create(vtkRenderWindowInteractor interactor, vtkInteractorStyle baseInteractorStyle)
+        => new(interactor, baseInteractorStyle);
 
     // ────────────────────── Action‑flavour APIs (unchanged) ──────────────────────
 
-    public MouseInteractorBuilder LeftMove(MousePosHandler h, KeyMask k = KeyMask.None, bool swallow = false)
-        => AddMouseAction(TriggerMouseButton.Left, drag: false, h, k, swallow);
+    public MouseInteractorBuilder LeftMove(MousePosHandler handler, KeyModifier key = KeyModifier.None, bool swallowEvent = false)
+        => AddMouseAction(TriggerMouseButton.Left, isDrag: false, handler, key, swallowEvent);
 
-    public MouseInteractorBuilder LeftDrag(MousePosHandler h, KeyMask k = KeyMask.None, bool swallow = false)
-        => AddMouseAction(TriggerMouseButton.Left, drag: true, h, k, swallow);
+    public MouseInteractorBuilder LeftDrag(MousePosHandler handler, KeyModifier key = KeyModifier.None, bool swallowEvent = false)
+        => AddMouseAction(TriggerMouseButton.Left, isDrag: true, handler, key, swallowEvent);
 
-    public MouseInteractorBuilder RightMove(MousePosHandler h, KeyMask k = KeyMask.None, bool swallow = false)
-        => AddMouseAction(TriggerMouseButton.Right, drag: false, h, k, swallow);
+    public MouseInteractorBuilder RightMove(MousePosHandler handler, KeyModifier key = KeyModifier.None, bool swallowEvent = false)
+        => AddMouseAction(TriggerMouseButton.Right, isDrag: false, handler, key, swallowEvent);
 
-    public MouseInteractorBuilder RightDrag(MousePosHandler h, KeyMask k = KeyMask.None, bool swallow = false)
-        => AddMouseAction(TriggerMouseButton.Right, drag: true, h, k, swallow);
+    public MouseInteractorBuilder RightDrag(MousePosHandler handler, KeyModifier key = KeyModifier.None, bool swallowEvent = false)
+        => AddMouseAction(TriggerMouseButton.Right, isDrag: true, handler, key, swallowEvent);
 
-    public MouseInteractorBuilder MiddleMove(MousePosHandler h, KeyMask k = KeyMask.None, bool swallow = false)
-        => AddMouseAction(TriggerMouseButton.Middle, drag: false, h, k, swallow);
+    public MouseInteractorBuilder MiddleMove(MousePosHandler handler, KeyModifier key = KeyModifier.None, bool swallowEvent = false)
+        => AddMouseAction(TriggerMouseButton.Middle, isDrag: false, handler, key, swallowEvent);
 
-    public MouseInteractorBuilder MiddleDrag(MousePosHandler h, KeyMask k = KeyMask.None, bool swallow = false)
-        => AddMouseAction(TriggerMouseButton.Middle, drag: true, h, k, swallow);
+    public MouseInteractorBuilder MiddleDrag(MousePosHandler handler, KeyModifier key = KeyModifier.None, bool swallowEvent = false)
+        => AddMouseAction(TriggerMouseButton.Middle, isDrag: true, handler, key, swallowEvent);
 
-    public MouseInteractorBuilder Scroll(Action<bool> h, KeyMask k = KeyMask.None, bool swallow = true)
-        => ScrollRx(obs => obs.Subscribe(h), k, swallow);
+    public MouseInteractorBuilder Scroll(Action<bool> handler, KeyModifier key = KeyModifier.None, bool swallowEvent = true)
+        => ScrollRx(observable => observable.Subscribe(handler), key, swallowEvent);
 
     // ─────────────────────────── Rx‑flavour APIs ────────────────────────────
 
-    public MouseInteractorBuilder LeftMoveRx(Func<IObservable<(int x, int y)>, IDisposable> sub,
-        KeyMask k = KeyMask.None,
-        bool swallow = false)
-        => AddMouseRx(TriggerMouseButton.Left, drag: false, sub, k, swallow);
+    public MouseInteractorBuilder LeftMoveRx(Func<IObservable<(int x, int y)>, IDisposable> subscriptionFactory,
+        KeyModifier key = KeyModifier.None,
+        bool swallowEvent = false)
+        => AddMouseRx(TriggerMouseButton.Left, isDrag: false, subscriptionFactory, key, swallowEvent);
 
-    public MouseInteractorBuilder LeftDragRx(Func<IObservable<(int x, int y)>, IDisposable> sub,
-        KeyMask k = KeyMask.None,
-        bool swallow = false)
-        => AddMouseRx(TriggerMouseButton.Left, drag: true, sub, k, swallow);
+    public MouseInteractorBuilder LeftDragRx(Func<IObservable<(int x, int y)>, IDisposable> subscriptionFactory,
+        KeyModifier key = KeyModifier.None,
+        bool swallowEvent = false)
+        => AddMouseRx(TriggerMouseButton.Left, isDrag: true, subscriptionFactory, key, swallowEvent);
 
-    public MouseInteractorBuilder RightMoveRx(Func<IObservable<(int x, int y)>, IDisposable> sub,
-        KeyMask k = KeyMask.None,
-        bool swallow = false)
-        => AddMouseRx(TriggerMouseButton.Right, drag: false, sub, k, swallow);
+    public MouseInteractorBuilder RightMoveRx(Func<IObservable<(int x, int y)>, IDisposable> subscriptionFactory,
+        KeyModifier key = KeyModifier.None,
+        bool swallowEvent = false)
+        => AddMouseRx(TriggerMouseButton.Right, isDrag: false, subscriptionFactory, key, swallowEvent);
 
-    public MouseInteractorBuilder RightDragRx(Func<IObservable<(int x, int y)>, IDisposable> sub,
-        KeyMask k = KeyMask.None,
-        bool swallow = false)
-        => AddMouseRx(TriggerMouseButton.Right, drag: true, sub, k, swallow);
+    public MouseInteractorBuilder RightDragRx(Func<IObservable<(int x, int y)>, IDisposable> subscriptionFactory,
+        KeyModifier key = KeyModifier.None,
+        bool swallowEvent = false)
+        => AddMouseRx(TriggerMouseButton.Right, isDrag: true, subscriptionFactory, key, swallowEvent);
 
-    public MouseInteractorBuilder MiddleMoveRx(Func<IObservable<(int x, int y)>, IDisposable> sub,
-        KeyMask k = KeyMask.None,
-        bool swallow = false)
-        => AddMouseRx(TriggerMouseButton.Middle, drag: false, sub, k, swallow);
+    public MouseInteractorBuilder MiddleMoveRx(Func<IObservable<(int x, int y)>, IDisposable> subscriptionFactory,
+        KeyModifier key = KeyModifier.None,
+        bool swallowEvent = false)
+        => AddMouseRx(TriggerMouseButton.Middle, isDrag: false, subscriptionFactory, key, swallowEvent);
 
-    public MouseInteractorBuilder MiddleDragRx(Func<IObservable<(int x, int y)>, IDisposable> sub,
-        KeyMask k = KeyMask.None,
-        bool swallow = false)
-        => AddMouseRx(TriggerMouseButton.Middle, drag: true, sub, k, swallow);
+    public MouseInteractorBuilder MiddleDragRx(Func<IObservable<(int x, int y)>, IDisposable> subscriptionFactory,
+        KeyModifier key = KeyModifier.None,
+        bool swallowEvent = false)
+        => AddMouseRx(TriggerMouseButton.Middle, isDrag: true, subscriptionFactory, key, swallowEvent);
 
-    public MouseInteractorBuilder ScrollRx(Func<IObservable<bool>, IDisposable> sub,
-        KeyMask k = KeyMask.None,
-        bool swallow = true)
+    public MouseInteractorBuilder ScrollRx(Func<IObservable<bool>, IDisposable> subscriptionFactory,
+        KeyModifier key = KeyModifier.None,
+        bool swallowEvent = true)
     {
-        if (swallow)
+        if (swallowEvent)
         {
             _bus.AddSwallow(VtkEventId.WheelForward);
             _bus.AddSwallow(VtkEventId.WheelBackward);
         }
         var beh = new ScrollInteractorBehavior(_bus);
-        _d.Add(beh);
-        _d.Add(sub(beh.Scrolls.Where(_ => k.IsSatisfied(_iren))));
+        _disposables.Add(beh);
+        _disposables.Add(subscriptionFactory(beh.Scrolls.Where(_ => key.IsSatisfied(_iren))));
         return this;
     }
 
     // ─────────────────────────────── Build ────────────────────────────────
 
-    public IDisposable Build() => _d;
+    public IDisposable Build() => _disposables;
 
     // ────────────────────────── Internal helpers ──────────────────────────
 
-    private MouseInteractorBuilder AddMouseAction(TriggerMouseButton btn,
-        bool drag,
-        MousePosHandler h,
-        KeyMask k,
-        bool swallow)
-        => AddMouseRx(btn, drag, obs => obs.Subscribe(p => h(p.x, p.y)), k, swallow);
+    private MouseInteractorBuilder AddMouseAction(TriggerMouseButton mouseButton,
+        bool isDrag,
+        MousePosHandler handler,
+        KeyModifier key,
+        bool swallowEvent)
+        => AddMouseRx(mouseButton, isDrag, observable => observable.Subscribe(p => handler(p.x, p.y)), key, swallowEvent);
 
-    private MouseInteractorBuilder AddMouseRx(TriggerMouseButton btn,
-        bool drag,
-        Func<IObservable<(int x, int y)>, IDisposable> sub,
-        KeyMask k,
-        bool swallow)
+    private MouseInteractorBuilder AddMouseRx(TriggerMouseButton mouseButton,
+        bool isDrag,
+        Func<IObservable<(int x, int y)>, IDisposable> subscriptionFactory,
+        KeyModifier key,
+        bool swallowEvent)
     {
-        if (swallow)
+        if (swallowEvent)
         {
             _bus.AddSwallow(VtkEventId.MouseMove);
-            _bus.AddSwallow(btn switch
+            _bus.AddSwallow(mouseButton switch
             {
                 TriggerMouseButton.Left => VtkEventId.LeftDown,
                 TriggerMouseButton.Right => VtkEventId.RightDown,
                 TriggerMouseButton.Middle => VtkEventId.MiddleDown,
-                _ => throw new ArgumentOutOfRangeException()
+                _ => throw new ArgumentOutOfRangeException(nameof(mouseButton), mouseButton, null)
             });
-            _bus.AddSwallow(btn switch
+            _bus.AddSwallow(mouseButton switch
             {
                 TriggerMouseButton.Left => VtkEventId.LeftUp,
                 TriggerMouseButton.Right => VtkEventId.RightUp,
                 TriggerMouseButton.Middle => VtkEventId.MiddleUp,
-                _ => throw new ArgumentOutOfRangeException()
+                _ => throw new ArgumentOutOfRangeException(nameof(mouseButton), mouseButton, null)
             });
         }
 
-        var beh = new MouseInteractorBehavior(_bus, btn);
-        _d.Add(beh);
-        IObservable<(int x, int y)> stream = beh.Moves.Where(_ => k.IsSatisfied(_iren));
-        if (drag) stream = stream.Where(_ => beh.IsPressing);
-        _d.Add(sub(stream));
+        var beh = new MouseInteractorBehavior(_bus, mouseButton);
+        _disposables.Add(beh);
+        
+        // Filter the stream by pressing checks and keymask
+        IObservable<(int x, int y)> stream = beh.Moves.Where(_ => key.IsSatisfied(_iren));
+        if (isDrag) stream = stream.Where(_ => beh.IsPressing);
+        
+        _disposables.Add(subscriptionFactory(stream));
         return this;
     }
 }

--- a/VtkMvvm/Features/InteractorBehavior/MouseInteractorBuilder.cs
+++ b/VtkMvvm/Features/InteractorBehavior/MouseInteractorBuilder.cs
@@ -31,191 +31,136 @@ public delegate void MousePosHandler(int x, int y);
 /// </summary>
 public sealed class MouseInteractorBuilder
 {
-    // ───────────────────────── fields ─────────────────────────
     private readonly vtkRenderWindowInteractor _iren;
-    private readonly vtkInteractorStyle _style;
-    private readonly CompositeDisposable _disposables = new();
-    private readonly List<IInteractorBehavior> _behaviours = new();
+    private readonly BaseForwarder _bus;
+    private readonly CompositeDisposable _d = new();
 
-    // ─────────────────────── constructor ─────────────────────
     private MouseInteractorBuilder(vtkRenderWindowInteractor iren, vtkInteractorStyle baseStyle)
     {
-        _iren = iren ?? throw new ArgumentNullException(nameof(iren));
-        _style = baseStyle ?? throw new ArgumentNullException(nameof(baseStyle));
+        _iren = iren;
+        _bus = new BaseForwarder(baseStyle);
+        _d.Add(_bus);
+
+        iren.SetInteractorStyle(baseStyle);
+        iren.Initialize();
     }
 
-    // ─────────────────────── factory ─────────────────────────
     public static MouseInteractorBuilder Create(vtkRenderWindowInteractor iren, vtkInteractorStyle baseStyle)
         => new(iren, baseStyle);
 
-    // ═══════════════════════════════════════════════════════════════════════
-    //  Rx-FLAVOUR  – caller handles the IObservable
-    // ═══════════════════════════════════════════════════════════════════════
+    // ────────────────────── Action‑flavour APIs (unchanged) ──────────────────────
 
-    #region Rx APIs
+    public MouseInteractorBuilder LeftMove(MousePosHandler h, KeyMask k = KeyMask.None, bool swallow = false)
+        => AddMouseAction(TriggerMouseButton.Left, drag: false, h, k, swallow);
+
+    public MouseInteractorBuilder LeftDrag(MousePosHandler h, KeyMask k = KeyMask.None, bool swallow = false)
+        => AddMouseAction(TriggerMouseButton.Left, drag: true, h, k, swallow);
+
+    public MouseInteractorBuilder RightMove(MousePosHandler h, KeyMask k = KeyMask.None, bool swallow = false)
+        => AddMouseAction(TriggerMouseButton.Right, drag: false, h, k, swallow);
+
+    public MouseInteractorBuilder RightDrag(MousePosHandler h, KeyMask k = KeyMask.None, bool swallow = false)
+        => AddMouseAction(TriggerMouseButton.Right, drag: true, h, k, swallow);
+
+    public MouseInteractorBuilder MiddleMove(MousePosHandler h, KeyMask k = KeyMask.None, bool swallow = false)
+        => AddMouseAction(TriggerMouseButton.Middle, drag: false, h, k, swallow);
+
+    public MouseInteractorBuilder MiddleDrag(MousePosHandler h, KeyMask k = KeyMask.None, bool swallow = false)
+        => AddMouseAction(TriggerMouseButton.Middle, drag: true, h, k, swallow);
+
+    public MouseInteractorBuilder Scroll(Action<bool> h, KeyMask k = KeyMask.None, bool swallow = true)
+        => ScrollRx(obs => obs.Subscribe(h), k, swallow);
+
+    // ─────────────────────────── Rx‑flavour APIs ────────────────────────────
 
     public MouseInteractorBuilder LeftMoveRx(Func<IObservable<(int x, int y)>, IDisposable> sub,
-        KeyMask keys = KeyMask.None,
+        KeyMask k = KeyMask.None,
         bool swallow = false)
-        => AddMouse(TriggerMouseButton.Left, drag: false, sub, keys, swallow);
+        => AddMouseRx(TriggerMouseButton.Left, drag: false, sub, k, swallow);
 
     public MouseInteractorBuilder LeftDragRx(Func<IObservable<(int x, int y)>, IDisposable> sub,
-        KeyMask keys = KeyMask.None,
+        KeyMask k = KeyMask.None,
         bool swallow = false)
-        => AddMouse(TriggerMouseButton.Left, drag: true, sub, keys, swallow);
+        => AddMouseRx(TriggerMouseButton.Left, drag: true, sub, k, swallow);
 
     public MouseInteractorBuilder RightMoveRx(Func<IObservable<(int x, int y)>, IDisposable> sub,
-        KeyMask keys = KeyMask.None,
+        KeyMask k = KeyMask.None,
         bool swallow = false)
-        => AddMouse(TriggerMouseButton.Right, false, sub, keys, swallow);
+        => AddMouseRx(TriggerMouseButton.Right, drag: false, sub, k, swallow);
 
     public MouseInteractorBuilder RightDragRx(Func<IObservable<(int x, int y)>, IDisposable> sub,
-        KeyMask keys = KeyMask.None,
+        KeyMask k = KeyMask.None,
         bool swallow = false)
-        => AddMouse(TriggerMouseButton.Right, true, sub, keys, swallow);
+        => AddMouseRx(TriggerMouseButton.Right, drag: true, sub, k, swallow);
 
     public MouseInteractorBuilder MiddleMoveRx(Func<IObservable<(int x, int y)>, IDisposable> sub,
-        KeyMask keys = KeyMask.None,
+        KeyMask k = KeyMask.None,
         bool swallow = false)
-        => AddMouse(TriggerMouseButton.Middle, false, sub, keys, swallow);
+        => AddMouseRx(TriggerMouseButton.Middle, drag: false, sub, k, swallow);
 
     public MouseInteractorBuilder MiddleDragRx(Func<IObservable<(int x, int y)>, IDisposable> sub,
-        KeyMask keys = KeyMask.None,
+        KeyMask k = KeyMask.None,
         bool swallow = false)
-        => AddMouse(TriggerMouseButton.Middle, true, sub, keys, swallow);
+        => AddMouseRx(TriggerMouseButton.Middle, drag: true, sub, k, swallow);
 
     public MouseInteractorBuilder ScrollRx(Func<IObservable<bool>, IDisposable> sub,
-        KeyMask keys = KeyMask.None,
+        KeyMask k = KeyMask.None,
         bool swallow = true)
     {
-        var beh = new ScrollInteractorBehavior { OverrideBaseStyle = swallow };
-        Plug(beh,
-            _ => keys == KeyMask.None
-                ? beh.Scrolls
-                : beh.Scrolls.Where(_ => keys.IsSatisfied(_iren)),
-            sub);
+        if (swallow)
+        {
+            _bus.AddSwallow(VtkEventId.WheelForward);
+            _bus.AddSwallow(VtkEventId.WheelBackward);
+        }
+        var beh = new ScrollInteractorBehavior(_bus);
+        _d.Add(beh);
+        _d.Add(sub(beh.Scrolls.Where(_ => k.IsSatisfied(_iren))));
         return this;
     }
 
-    #endregion
+    // ─────────────────────────────── Build ────────────────────────────────
 
-    // ═══════════════════════════════════════════════════════════════════════
-    //  ACTION-FLAVOUR  – builder hides the Subscribe/Dispose dance
-    // ═══════════════════════════════════════════════════════════════════════
+    public IDisposable Build() => _d;
 
-    #region Action APIs
-
-    public MouseInteractorBuilder LeftMove(MousePosHandler handler,
-        KeyMask keys = KeyMask.None,
-        bool swallow = false)
-        => AddMouseAction(TriggerMouseButton.Left, drag: false, handler, keys, swallow);
-
-    public MouseInteractorBuilder LeftDrag(MousePosHandler handler,
-        KeyMask keys = KeyMask.None,
-        bool swallow = false)
-        => AddMouseAction(TriggerMouseButton.Left, true, handler, keys, swallow);
-
-    public MouseInteractorBuilder RightMove(MousePosHandler handler,
-        KeyMask keys = KeyMask.None,
-        bool swallow = false)
-        => AddMouseAction(TriggerMouseButton.Right, false, handler, keys, swallow);
-
-    public MouseInteractorBuilder RightDrag(MousePosHandler handler,
-        KeyMask keys = KeyMask.None,
-        bool swallow = false)
-        => AddMouseAction(TriggerMouseButton.Right, true, handler, keys, swallow);
-
-    public MouseInteractorBuilder MiddleMove(MousePosHandler handler,
-        KeyMask keys = KeyMask.None,
-        bool swallow = false)
-        => AddMouseAction(TriggerMouseButton.Middle, false, handler, keys, swallow);
-
-    public MouseInteractorBuilder MiddleDrag(MousePosHandler handler,
-        KeyMask keys = KeyMask.None,
-        bool swallow = false)
-        => AddMouseAction(TriggerMouseButton.Middle, true, handler, keys, swallow);
-
-    public MouseInteractorBuilder Scroll(Action<bool> handler,
-        KeyMask keys = KeyMask.None,
-        bool swallow = true)
-        => ScrollRx(obs => obs.Subscribe(handler), keys, swallow);
-
-    #endregion
-
-    // ═══════════════════════════════════════════════════════════════════════
-    //  Build / Dispose
-    // ═══════════════════════════════════════════════════════════════════════
-    /// <returns>
-    ///     A composite disposable that:
-    ///     <list type="bullet">
-    ///         <item><description>unsubscribes all Rx streams</description></item>
-    ///         <item><description>detaches every <see cref="IInteractorBehavior"/></description></item>
-    ///     </list>
-    /// </returns>
-    public IDisposable Build()
-    {
-        _iren.SetInteractorStyle(_style);
-        _iren.Initialize();
-
-        _disposables.Add(Disposable.Create(() =>
-        {
-            foreach (var b in _behaviours) b.Detach();
-        }));
-        return _disposables;
-    }
-
-    // ═══════════════════════════════════════════════════════════════════════
-    //  Internal helpers
-    // ═══════════════════════════════════════════════════════════════════════
-
-    #region Internal plumbing
-
-    private MouseInteractorBuilder AddMouse(TriggerMouseButton btn,
-        bool drag,
-        Func<IObservable<(int x, int y)>, IDisposable> sub,
-        KeyMask keys,
-        bool swallow)
-    {
-        return AddMouseBehaviour(btn, drag, keys, sub, swallow);
-    }
+    // ────────────────────────── Internal helpers ──────────────────────────
 
     private MouseInteractorBuilder AddMouseAction(TriggerMouseButton btn,
         bool drag,
-        MousePosHandler handler,
-        KeyMask keys,
+        MousePosHandler h,
+        KeyMask k,
         bool swallow)
-    {
-        // Wrap into Rx flavour internally
-        return AddMouse(btn, drag,
-            obs => obs.Subscribe(p => handler(p.x, p.y)),
-            keys, swallow);
-    }
+        => AddMouseRx(btn, drag, obs => obs.Subscribe(p => h(p.x, p.y)), k, swallow);
 
-    private MouseInteractorBuilder AddMouseBehaviour(TriggerMouseButton button,
+    private MouseInteractorBuilder AddMouseRx(TriggerMouseButton btn,
         bool drag,
-        KeyMask keys,
-        Func<IObservable<(int x, int y)>, IDisposable> subscriber,
+        Func<IObservable<(int x, int y)>, IDisposable> sub,
+        KeyMask k,
         bool swallow)
     {
-        var beh = new MouseInteractorBehavior(button) { OverrideBaseStyle = swallow };
+        if (swallow)
+        {
+            _bus.AddSwallow(VtkEventId.MouseMove);
+            _bus.AddSwallow(btn switch
+            {
+                TriggerMouseButton.Left => VtkEventId.LeftDown,
+                TriggerMouseButton.Right => VtkEventId.RightDown,
+                TriggerMouseButton.Middle => VtkEventId.MiddleDown,
+                _ => throw new ArgumentOutOfRangeException()
+            });
+            _bus.AddSwallow(btn switch
+            {
+                TriggerMouseButton.Left => VtkEventId.LeftUp,
+                TriggerMouseButton.Right => VtkEventId.RightUp,
+                TriggerMouseButton.Middle => VtkEventId.MiddleUp,
+                _ => throw new ArgumentOutOfRangeException()
+            });
+        }
 
-        IObservable<(int x, int y)> stream = beh.Moves;
-        stream = stream.Where(_ => keys.IsSatisfied(_iren)); // key mask
-        if (drag) stream = stream.Where(_ => beh.IsPressing); // pressing mask
-
-        Plug(beh, _ => stream, subscriber);
+        var beh = new MouseInteractorBehavior(_bus, btn);
+        _d.Add(beh);
+        IObservable<(int x, int y)> stream = beh.Moves.Where(_ => k.IsSatisfied(_iren));
+        if (drag) stream = stream.Where(_ => beh.IsPressing);
+        _d.Add(sub(stream));
         return this;
     }
-
-    private void Plug<TStream>(IInteractorBehavior behaviour,
-        Func<IInteractorBehavior, IObservable<TStream>> streamSelector,
-        Func<IObservable<TStream>, IDisposable> subscriber)
-    {
-        behaviour.AttachTo(_style);
-        _behaviours.Add(behaviour);
-        _disposables.Add((IDisposable)behaviour); // dispose behaviour
-        _disposables.Add(subscriber(streamSelector(behaviour))); // dispose Rx
-    }
-
-    #endregion
 }

--- a/VtkMvvm/Features/InteractorBehavior/ScrollInteractorBehavior.cs
+++ b/VtkMvvm/Features/InteractorBehavior/ScrollInteractorBehavior.cs
@@ -23,5 +23,9 @@ public sealed class ScrollInteractorBehavior : IDisposable
             .Subscribe(_scrolls);
     }
 
-    public void Dispose() => _d.Dispose();
+    public void Dispose()
+    {
+        _d.Dispose();
+        _scrolls.Dispose();
+    }
 }

--- a/VtkMvvm/Features/InteractorBehavior/ScrollInteractorBehavior.cs
+++ b/VtkMvvm/Features/InteractorBehavior/ScrollInteractorBehavior.cs
@@ -1,59 +1,27 @@
-﻿using System.Reactive.Linq;
+﻿// ════════════════════════════════════════════════════════════════════════════════
+//  Behaviour: scroll wheel
+// ════════════════════════════════════════════════════════════════════════════════
+
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using Kitware.VTK;
 
 namespace VtkMvvm.Features.InteractorBehavior;
 
-public sealed class ScrollInteractorBehavior : IInteractorBehavior, IDisposable
+public sealed class ScrollInteractorBehavior : IDisposable
 {
-    private readonly Subject<bool> _scrollSubject = new();
-    private vtkInteractorStyle? _style;
-    
-    /// <summary>
-    /// Scroll forward emits true, scroll backward emits false
-    /// </summary>
-    public IObservable<bool> Scrolls => _scrollSubject.AsObservable();
-    
-    /// <summary>
-    /// If not override, will forward the base event handler
-    /// </summary>
-    public bool OverrideBaseStyle { get; set; } = false;
+    private readonly Subject<bool> _scrolls = new();
+    private readonly IDisposable _d;
 
-    public void Dispose()
+    /// <summary>True = wheel forward, false = wheel backward.</summary>
+    public IObservable<bool> Scrolls => _scrolls.AsObservable();
+
+    public ScrollInteractorBehavior(IObservable<VtkEvent> bus)
     {
-        Detach();
-        _scrollSubject.Dispose();
+        _d = bus
+            .Where(e => e.Id is VtkEventId.WheelForward or VtkEventId.WheelBackward)
+            .Select(e => e.Id == VtkEventId.WheelForward)
+            .Subscribe(_scrolls);
     }
 
-    public void AttachTo(vtkInteractorStyle style)
-    {
-        ArgumentNullException.ThrowIfNull(style);
-        _style = style;
-        _style.MouseWheelForwardEvt += OnScrollForward;
-        _style.MouseWheelBackwardEvt += OnScrollBackward;
-    }
-
-    public void Detach()
-    {
-        if (_style is null) return;
-        _style.MouseWheelForwardEvt -= OnScrollForward;
-        _style.MouseWheelBackwardEvt -= OnScrollBackward;
-        _style = null;
-    }
-
-    private void OnScrollBackward(vtkObject sender, vtkObjectEventArgs e)
-    {
-        _scrollSubject.OnNext(false);
-        if (OverrideBaseStyle) return;  // If override, don't call base style
-
-        _style!.OnMouseWheelBackward();
-    }
-
-    private void OnScrollForward(vtkObject sender, vtkObjectEventArgs e)
-    {
-        _scrollSubject.OnNext(true);
-        if (OverrideBaseStyle) return;  // If override, don't call base style
-
-        _style!.OnMouseWheelForward();
-    }
+    public void Dispose() => _d.Dispose();
 }

--- a/VtkMvvm/Features/InteractorBehavior/TriggerMouseButton.cs
+++ b/VtkMvvm/Features/InteractorBehavior/TriggerMouseButton.cs
@@ -3,7 +3,7 @@
 /// <summary>Which mouse button triggers a <see cref="MouseInteractorBehavior"/>.</summary>
 public enum TriggerMouseButton
 {
-    Left,
-    Right,
-    Middle
+    Left = 1,
+    Right = 2,
+    Middle = 3
 }

--- a/VtkMvvm/Features/InteractorBehavior/TriggerMouseButton.cs
+++ b/VtkMvvm/Features/InteractorBehavior/TriggerMouseButton.cs
@@ -1,0 +1,9 @@
+﻿namespace VtkMvvm.Features.InteractorBehavior;
+
+/// <summary>Which mouse button triggers a <see cref="MouseInteractorBehavior"/>.</summary>
+public enum TriggerMouseButton
+{
+    Left,
+    Right,
+    Middle
+}

--- a/VtkMvvm/Features/InteractorBehavior/VtkEventId.cs
+++ b/VtkMvvm/Features/InteractorBehavior/VtkEventId.cs
@@ -1,0 +1,22 @@
+﻿using Kitware.VTK;
+
+namespace VtkMvvm.Features.InteractorBehavior;
+
+
+/// <summary>Distinct VTK interaction events we care about.</summary>
+internal enum VtkEventId
+{
+    MouseMove,
+    LeftDown,
+    LeftUp,
+    RightDown,
+    RightUp,
+    MiddleDown,
+    MiddleUp,
+    WheelForward,
+    WheelBackward
+}
+
+/// <summary>Strong‑typed event payload that flows through the bus.</summary>
+internal readonly record struct VtkEvent(VtkEventId Id, vtkRenderWindowInteractor Iren);
+

--- a/VtkMvvm/Features/InteractorBehavior/VtkEventId.cs
+++ b/VtkMvvm/Features/InteractorBehavior/VtkEventId.cs
@@ -4,7 +4,7 @@ namespace VtkMvvm.Features.InteractorBehavior;
 
 
 /// <summary>Distinct VTK interaction events we care about.</summary>
-internal enum VtkEventId
+public enum VtkEventId
 {
     MouseMove,
     LeftDown,
@@ -18,5 +18,5 @@ internal enum VtkEventId
 }
 
 /// <summary>Strong‑typed event payload that flows through the bus.</summary>
-internal readonly record struct VtkEvent(VtkEventId Id, vtkRenderWindowInteractor Iren);
+public readonly record struct VtkEvent(VtkEventId Id, vtkRenderWindowInteractor Iren);
 


### PR DESCRIPTION
### Summary of Changes

- Renamed `KeyMask` to `KeyModifier` and added relevant comments and variable renames in `MouseInteractorBuilder`.
- Introduced `BaseForwarder` as a unified event bus, preventing redundant style base event forwarding.
- Added `BaseForwarder` to streamline event handling across the system.
- Introduced `VtkEventId` and `VtkEvent` for internal VTK event management.
